### PR TITLE
Make the dashboard UID generation a bit more complex... :(

### DIFF
--- a/charts/generic-prometheus-alerts/Chart.yaml
+++ b/charts/generic-prometheus-alerts/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/generic-prometheus-alerts/templates/_helpers.tpl
+++ b/charts/generic-prometheus-alerts/templates/_helpers.tpl
@@ -70,5 +70,6 @@ grafana_dashboard: ""
 Generate a UID prefix for the dashboards
 */}}
 {{- define "generic-prometheus-alerts.dashboardUIDPrefix" -}}
-{{- cat .Release.Namespace .Release.Name | b64enc | trunc 30 | trimSuffix "=" }}
+{{- $longUID := cat .Release.Namespace .Release.Name | replace " " "" | b64enc | replace "=" "" }}
+{{- regexSplit "" $longUID -1 | reverse | join "" | trunc 30 -}}
 {{- end }}


### PR DESCRIPTION
Similarly named applications in the same namespace (i.e. `something-api`
and `something-ui`) were producing the same UID as they were producing
the same string up until the last few characters, which we had to
truncate due to the length limitations.