### PR TITLE
Allow for the easy scraping of custom (prometheus) metrics

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1

--- a/charts/generic-service/templates/networkpolicy.yaml
+++ b/charts/generic-service/templates/networkpolicy.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.custommetrics.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "generic-service.fullname" . }}-monitoring
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "generic-service.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            component: monitoring
+{{- end }}

--- a/charts/generic-service/templates/servicemonitor.yaml
+++ b/charts/generic-service/templates/servicemonitor.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.custommetrics.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "generic-service.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "generic-service.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      interval: {{ .Values.custommetrics.scrapeInterval }}
+      path: {{ .Values.custommetrics.metricsPath }}
+{{- end }}

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -122,3 +122,8 @@ strategy:
   rollingUpdate:
     maxSurge: 100%
     maxUnavailable: 0
+
+custommetrics:
+  enabled: false
+  scrapeInterval: 15s
+  metricsPath: /metrics


### PR DESCRIPTION
This allows users to easily expose prometheus metrics from their
applications.

- The networkpolicy is needed to allow prometheus access to your
  applications namespace.
- The servicemonitor instructs prometheus where (and how often) to
  scrape metrics from.