### PR TITLE
Fix failed job false positives

### DIFF
--- a/.github/workflows/alert-test.yml
+++ b/.github/workflows/alert-test.yml
@@ -1,0 +1,45 @@
+---
+name: Alert Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  alert-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+
+      - name: Install yq
+        uses: chrisdickinson/setup-yq@latest
+        with:
+          yq-version: v4.16.1
+
+      - name: Install promtool
+        run: |
+          echo "Checking the latest version of Promtool"
+          promtoolVersion=$(git ls-remote --tags --refs --sort="v:refname"  git://github.com/prometheus/prometheus | grep -v '[-].*' | tail -n1 | sed 's/.*\///' | cut -c 2-)
+
+          url="https://github.com/prometheus/prometheus/releases/download/v${promtoolVersion}/prometheus-${promtoolVersion}.linux-amd64.tar.gz"
+
+          echo "Downloading Promtool v${promtoolVersion}"
+          curl -s -S -L -o /tmp/promtool_${promtoolVersion} ${url}
+
+          echo "Unzipping Promtool v${promtoolVersion}"
+          tar -zxf /tmp/promtool_${promtoolVersion} --strip-components=1 --directory /usr/local/bin &> /dev/null
+
+      - name: Test Alert Rules
+        run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+charts/generic-prometheus-alerts/ci/compiled-yaml.yaml
+charts/generic-prometheus-alerts/ci/application-alerts.yaml
+charts/generic-prometheus-alerts/ci/ingress-alerts.yaml
+charts/generic-prometheus-alerts/ci/test-application/Chart.lock
+charts/generic-prometheus-alerts/ci/test-application/charts

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ charts/generic-prometheus-alerts/ci/compiled-yaml.yaml
 charts/generic-prometheus-alerts/ci/application-alerts.yaml
 charts/generic-prometheus-alerts/ci/ingress-alerts.yaml
 charts/generic-prometheus-alerts/ci/test-application/Chart.lock
+charts/generic-prometheus-alerts/ci/test-application/Chart.yaml
 charts/generic-prometheus-alerts/ci/test-application/charts

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,7 @@ charts/generic-prometheus-alerts/ci/ingress-alerts.yaml: charts/generic-promethe
 	@cd charts/generic-prometheus-alerts/ci && yq eval 'select(.metadata.name == "test-application-ingress") | .spec' compiled-yaml.yaml > ingress-alerts.yaml
 
 charts/generic-prometheus-alerts/ci/compiled-yaml.yaml:
-	@echo "Compiling Chart YAML ..."
-	@cd charts/generic-prometheus-alerts/ci/test-application && helm dependency update
-	@cd charts/generic-prometheus-alerts/ci && helm template test-application test-application --dry-run --namespace test-application-dev > compiled-yaml.yaml
+	@./compile-generic-prometheus-alert-test-app-yaml.sh
 
 build: charts/generic-prometheus-alerts/ci/application-alerts.yaml charts/generic-prometheus-alerts/ci/ingress-alerts.yaml
 
@@ -25,4 +23,5 @@ clean:
 	rm -f charts/generic-prometheus-alerts/ci/application-alerts.yaml
 	rm -f charts/generic-prometheus-alerts/ci/ingress-alerts.yaml
 	rm -f charts/generic-prometheus-alerts/ci/test-application/Chart.lock
+	rm -f charts/generic-prometheus-alerts/ci/test-application/Chart.yaml
 	rm -rf charts/generic-prometheus-alerts/ci/test-application/charts

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ charts/generic-prometheus-alerts/ci/ingress-alerts.yaml: charts/generic-promethe
 charts/generic-prometheus-alerts/ci/compiled-yaml.yaml:
 	@echo "Compiling Chart YAML ..."
 	@cd charts/generic-prometheus-alerts/ci/test-application && helm dependency update
-	@cd charts/generic-prometheus-alerts/ci && helm template test-application test-application --dry-run > compiled-yaml.yaml
+	@cd charts/generic-prometheus-alerts/ci && helm template test-application test-application --dry-run --namespace test-application-dev > compiled-yaml.yaml
 
 build: charts/generic-prometheus-alerts/ci/application-alerts.yaml charts/generic-prometheus-alerts/ci/ingress-alerts.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+.PHONY: build test
+
+default: build
+
+charts/generic-prometheus-alerts/ci/application-alerts.yaml: charts/generic-prometheus-alerts/ci/compiled-yaml.yaml
+	@echo "Extracting Application Alerts ..."
+	@cd charts/generic-prometheus-alerts/ci && yq eval 'select(.metadata.name == "test-application-app") | .spec' compiled-yaml.yaml > application-alerts.yaml
+
+charts/generic-prometheus-alerts/ci/ingress-alerts.yaml: charts/generic-prometheus-alerts/ci/compiled-yaml.yaml
+	@echo "Extracting Ingress Alerts ..."
+	@cd charts/generic-prometheus-alerts/ci && yq eval 'select(.metadata.name == "test-application-ingress") | .spec' compiled-yaml.yaml > ingress-alerts.yaml
+
+charts/generic-prometheus-alerts/ci/compiled-yaml.yaml:
+	@echo "Compiling Chart YAML ..."
+	@cd charts/generic-prometheus-alerts/ci/test-application && helm dependency update
+	@cd charts/generic-prometheus-alerts/ci && helm template test-application test-application --dry-run > compiled-yaml.yaml
+
+build: charts/generic-prometheus-alerts/ci/application-alerts.yaml charts/generic-prometheus-alerts/ci/ingress-alerts.yaml
+
+test: clean build
+	promtool test rules charts/generic-prometheus-alerts/ci/tests/*.yaml
+
+clean:
+	rm -f charts/generic-prometheus-alerts/ci/compiled-yaml.yaml
+	rm -f charts/generic-prometheus-alerts/ci/application-alerts.yaml
+	rm -f charts/generic-prometheus-alerts/ci/ingress-alerts.yaml
+	rm -f charts/generic-prometheus-alerts/ci/test-application/Chart.lock
+	rm -rf charts/generic-prometheus-alerts/ci/test-application/charts

--- a/README.md
+++ b/README.md
@@ -61,4 +61,23 @@ You can also compare the template yaml by running the following both before and 
 helm -n my-namespace template <release-name> <directory-containing-project-chart> --values=<values-file>
 ```
 
+## Unit Testing Prometheus Alerts
+
+To run the unit tests you will need both [yq] and promtool installed, these can be installed on a mac via homebrew:
+
+```shell
+brew install yq prometheus
+```
+
+Then simply run the following to run the unit tests:
+
+```shell
+make test
+```
+
+More information on how to write a prometheus rule unit test can be found on the prometheus website:
+
+https://www.prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/
+
 [version_list]: https://structurizr.com/share/56937/documentation/*#2
+[yq]: http://mikefarah.github.io/yq/

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ helm -n my-namespace template <release-name> <directory-containing-project-chart
 
 ## Unit Testing Prometheus Alerts
 
-To run the unit tests you will need both [yq] and promtool installed, these can be installed on a mac via homebrew:
+To run the unit tests you will need both [yq], envsubst and promtool installed, these can be installed on a mac via homebrew:
 
 ```shell
-brew install yq prometheus
+brew install yq prometheus gettext
 ```
 
 Then simply run the following to run the unit tests:

--- a/charts/generic-prometheus-alerts/Chart.yaml
+++ b/charts/generic-prometheus-alerts/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.8
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/generic-prometheus-alerts/RUNBOOK.md
+++ b/charts/generic-prometheus-alerts/RUNBOOK.md
@@ -110,6 +110,17 @@ pods=$(kubectl -n <namespace> get pods --selector=job-name=<job> --output=jsonpa
 kubectl -n <namespace> logs $pods
 ```
 
+### application-cronjob-failed
+
+> CronJob `<namespace>`/`<cronjob>` failed to complete.
+
+You'll need to look at the logs from the (job) pods which this cronjob was running to investigate the issues. You can do this using the logging service or with a couple of commands like so (substituting in the namespace and cronjob name):
+
+```
+pods=$(kubectl -n <namespace> get pods --selector=job-name=<cronjob> --output=jsonpath='{.items[*].metadata.name}')
+kubectl -n <namespace> logs $pods
+```
+
 ### application-hpa-replicas-mismatch
 
 > HPA `<namespace>`/`<hpa>` has not matched the desired number of replicas for longer than 15 minutes.

--- a/charts/generic-prometheus-alerts/RUNBOOK.md
+++ b/charts/generic-prometheus-alerts/RUNBOOK.md
@@ -99,17 +99,6 @@ pod=$(kubectl -n <namespace> get pods --selector=job-name=<job> --sort-by=.metad
 kubectl -n <namespace> logs $pod
 ```
 
-### application-job-failed
-
-> Job `<namespace>`/`<job>` failed to complete.
-
-You'll need to look at the logs from the pods which this job was running to investigate the issues. You can do this using the logging service or with a couple of commands like so (substituting in the namespace and job name):
-
-```
-pods=$(kubectl -n <namespace> get pods --selector=job-name=<job> --output=jsonpath='{.items[*].metadata.name}')
-kubectl -n <namespace> logs $pods
-```
-
 ### application-cronjob-failed
 
 > CronJob `<namespace>`/`<cronjob>` failed to complete.

--- a/charts/generic-prometheus-alerts/ci/test-application/Chart.tpl.yaml
+++ b/charts/generic-prometheus-alerts/ci/test-application/Chart.tpl.yaml
@@ -6,5 +6,5 @@ version: 0.2.0
 
 dependencies:
   - name: generic-prometheus-alerts
-    version: 0.3.0 # TODO: make this automatically update with actual chart version (use envsubst or something)
+    version: $CHART_VERSION
     repository: file://../../

--- a/charts/generic-prometheus-alerts/ci/test-application/Chart.yaml
+++ b/charts/generic-prometheus-alerts/ci/test-application/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.2.0
 
 dependencies:
   - name: generic-prometheus-alerts
-    version: 0.2.8 # TODO: make this automatically update with actual chart version (use envsubst or something)
+    version: 0.3.0 # TODO: make this automatically update with actual chart version (use envsubst or something)
     repository: file://../../

--- a/charts/generic-prometheus-alerts/ci/test-application/Chart.yaml
+++ b/charts/generic-prometheus-alerts/ci/test-application/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: test-application
+version: 0.2.0
+
+dependencies:
+  - name: generic-prometheus-alerts
+    version: 0.2.8 # TODO: make this automatically update with actual chart version (use envsubst or something)
+    repository: file://../../

--- a/charts/generic-prometheus-alerts/ci/test-application/values.yaml
+++ b/charts/generic-prometheus-alerts/ci/test-application/values.yaml
@@ -1,0 +1,5 @@
+---
+generic-prometheus-alerts:
+  targetApplication: "test-application"
+  runbookUrl: "https://runbook.com/"
+  alertSeverity: "alert-severity-tag"

--- a/charts/generic-prometheus-alerts/ci/tests/application-alerts-tests.yaml
+++ b/charts/generic-prometheus-alerts/ci/tests/application-alerts-tests.yaml
@@ -2,36 +2,116 @@
 rule_files:
   - ../application-alerts.yaml
 
-evaluation_interval: 1m
+evaluation_interval: 5m
 
 tests:
-  # KubeJobFailed - check that we get an alert on failure
-  - interval: 1m
-    # Series data.
+  ##
+  ## recording rules:
+  ##   - job:kube_job_status_start_time:max (last start time of a cronjob run)
+  ##   - job:kube_job_status_failed:sum (did the last job - in a cronjob - fail?)
+  ## alert:
+  ##   - CronJobStatusFailed - did the last run of a cronjob fail?
+  ##
+
+  # example one - two jobs (from the same cronjob) have run and failed
+  - interval: 5m
     input_series:
-      - series: 'up{job="prometheus", instance="localhost:9090"}'
-        values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
-      - series: 'up{job="node_exporter", instance="localhost:9100"}'
-        values: '1+0x6 0 0 0 0 0 0 0 0' # 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0
-      - series: 'go_goroutines{job="prometheus", instance="localhost:9090"}'
-        values: '10+10x2 30+20x5' # 10 20 30 30 50 70 90 110 130
-      - series: 'go_goroutines{job="node_exporter", instance="localhost:9100"}'
-        values: '10+10x7 10+30x4' # 10 20 30 40 50 60 70 80 10 40 70 100 130
+      - series: 'kube_job_status_failed{job="kube-state-metrics", job_name="test-application-cronjob-1", namespace="test-application-dev", reason="BackoffLimitExceeded"}'
+        values: '1+0x12'
+      - series: 'kube_job_status_start_time{job="kube-state-metrics", job_name="test-application-cronjob-1", namespace="test-application-dev"}'
+        values: '0+0x12'
+      - series: 'kube_job_owner{job="kube-state-metrics", job_name="test-application-cronjob-1", namespace="test-application-dev", owner_kind="CronJob", owner_name="test-application-cronjob"}'
+        values: '1+1x12'
+      - series: 'kube_cronjob_spec_suspend{cronjob="test-application-cronjob", job="kube-state-metrics", namespace="test-application-dev"}'
+        values: '0+0x12'
 
-    # Unit test for alerting rules.
+      - series: 'kube_job_status_failed{job="kube-state-metrics", job_name="test-application-cronjob-2", namespace="test-application-dev", reason="DeadLineExceeded"}'
+        values: '1+0x12'
+      - series: 'kube_job_status_start_time{job="kube-state-metrics", job_name="test-application-cronjob-2", namespace="test-application-dev"}'
+        values: '900+0x12'
+      - series: 'kube_job_owner{job="kube-state-metrics", job_name="test-application-cronjob-2", namespace="test-application-dev", owner_kind="CronJob", owner_name="test-application-cronjob"}'
+        values: '1+1x12'
+      - series: 'kube_cronjob_spec_suspend{cronjob="test-application-cronjob", job="kube-state-metrics", namespace="test-application-dev"}'
+        values: '0+0x12'
+
+    promql_expr_test:
+      # assert we're getting the timestamp of the last ran job...
+      - expr: job:kube_job_status_start_time:max
+        eval_time: 0m
+        exp_samples:
+          - labels: 'job:kube_job_status_start_time:max{cronjob="test-application-cronjob", job="test-application-cronjob-2", job_name="test-application-cronjob-2", namespace="test-application-dev", owner_name="test-application-cronjob"}'
+            value: 900
+
+      # assert that the last ran job failed
+      - expr: job:kube_job_status_failed:sum
+        eval_time: 0m
+        exp_samples:
+          - labels: 'job:kube_job_status_failed:sum{cronjob="test-application-cronjob", job="test-application-cronjob-2", job_name="test-application-cronjob-2", namespace="test-application-dev", owner_name="test-application-cronjob"}'
+            value: 1
+
     alert_rule_test:
-      # Unit test 1.
-      - eval_time: 10m
-        alertname: InstanceDown
+      # assert that the CronJobStatusFailed alert is firing
+      - eval_time: 35m
+        alertname: CronJobStatusFailed
         exp_alerts:
-          # Alert 1.
           - exp_labels:
-              severity: page
-              instance: localhost:9090
-              job: prometheus
+              cronjob: test-application-cronjob
+              job: test-application-cronjob-2
+              job_name: test-application-cronjob-2
+              namespace: test-application-dev
+              owner_name: test-application-cronjob
+              severity: alert-severity-tag
             exp_annotations:
-              summary: "Instance localhost:9090 down"
-              description: "localhost:9090 of job prometheus has been down for more than 5 minutes."
+              message: CronJob test-application-dev/test-application-cronjob is failing.
+              runbook_url: https://runbook.com/application-cronjob-failed
+              summary: CronJob is failing.
 
 
-  # KubeJobFailed - check that alert is cleared after successful run
+  # example two - three jobs (from the same cronjob) have run, the first two failed, the last one succeeded
+  - interval: 5m
+    input_series:
+      - series: 'kube_job_status_failed{job="kube-state-metrics", job_name="test-application-cronjob-1", namespace="test-application-dev", reason="BackoffLimitExceeded"}'
+        values: '1+0x12'
+      - series: 'kube_job_status_start_time{job="kube-state-metrics", job_name="test-application-cronjob-1", namespace="test-application-dev"}'
+        values: '0+0x12'
+      - series: 'kube_job_owner{job="kube-state-metrics", job_name="test-application-cronjob-1", namespace="test-application-dev", owner_kind="CronJob", owner_name="test-application-cronjob"}'
+        values: '1+0x12'
+      - series: 'kube_cronjob_spec_suspend{cronjob="test-application-cronjob", job="kube-state-metrics", namespace="test-application-dev"}'
+        values: '0+0x12'
+
+      - series: 'kube_job_status_failed{job="kube-state-metrics", job_name="test-application-cronjob-2", namespace="test-application-dev", reason="DeadLineExceeded"}'
+        values: '1+0x12'
+      - series: 'kube_job_status_start_time{job="kube-state-metrics", job_name="test-application-cronjob-2", namespace="test-application-dev"}'
+        values: '900+0x12'
+      - series: 'kube_job_owner{job="kube-state-metrics", job_name="test-application-cronjob-2", namespace="test-application-dev", owner_kind="CronJob", owner_name="test-application-cronjob"}'
+        values: '1+0x12'
+      - series: 'kube_cronjob_spec_suspend{cronjob="test-application-cronjob", job="kube-state-metrics", namespace="test-application-dev"}'
+        values: '0+0x12'
+
+      - series: 'kube_job_status_failed{job="kube-state-metrics", job_name="test-application-cronjob-3", namespace="test-application-dev"}'
+        values: '0+0x12'
+      - series: 'kube_job_status_start_time{job="kube-state-metrics", job_name="test-application-cronjob-3", namespace="test-application-dev"}'
+        values: '1800+0x12'
+      - series: 'kube_job_owner{job="kube-state-metrics", job_name="test-application-cronjob-3", namespace="test-application-dev", owner_kind="CronJob", owner_name="test-application-cronjob"}'
+        values: '1+0x12'
+      - series: 'kube_cronjob_spec_suspend{cronjob="test-application-cronjob", job="kube-state-metrics", namespace="test-application-dev"}'
+        values: '0+0x12'
+
+    promql_expr_test:
+      # assert we're getting the timestamp of the last ran job...
+      - expr: job:kube_job_status_start_time:max
+        eval_time: 0m
+        exp_samples:
+          - labels: 'job:kube_job_status_start_time:max{cronjob="test-application-cronjob", job="test-application-cronjob-3", job_name="test-application-cronjob-3", namespace="test-application-dev", owner_name="test-application-cronjob"}'
+            value: 1800
+
+      # assert that the last ran job did not fail (we expect nil from the rule)
+      - expr: job:kube_job_status_failed:sum
+        eval_time: 0m
+        exp_samples: []
+
+    alert_rule_test:
+      # check that the CronJobStatusFailed alert is NOT firing
+      - eval_time: 60m
+        alertname: CronJobStatusFailed
+        exp_alerts: []

--- a/charts/generic-prometheus-alerts/ci/tests/application-alerts-tests.yaml
+++ b/charts/generic-prometheus-alerts/ci/tests/application-alerts-tests.yaml
@@ -7,8 +7,8 @@ evaluation_interval: 5m
 tests:
   ##
   ## recording rules:
-  ##   - job:kube_job_status_start_time:max (last start time of a cronjob run)
-  ##   - job:kube_job_status_failed:sum (did the last job - in a cronjob - fail?)
+  ##   - job:kube_job_status_start_time_<namespace>:max (last start time of a cronjob run)
+  ##   - job:kube_job_status_failed_<namespace>:sum (did the last job - in a cronjob - fail?)
   ## alert:
   ##   - CronJobStatusFailed - did the last run of a cronjob fail?
   ##
@@ -36,17 +36,17 @@ tests:
 
     promql_expr_test:
       # assert we're getting the timestamp of the last ran job...
-      - expr: job:kube_job_status_start_time:max
+      - expr: job:kube_job_status_start_time_test_application_dev:max
         eval_time: 0m
         exp_samples:
-          - labels: 'job:kube_job_status_start_time:max{cronjob="test-application-cronjob", job="test-application-cronjob-2", job_name="test-application-cronjob-2", namespace="test-application-dev", owner_name="test-application-cronjob"}'
+          - labels: 'job:kube_job_status_start_time_test_application_dev:max{cronjob="test-application-cronjob", job="test-application-cronjob-2", job_name="test-application-cronjob-2", namespace="test-application-dev", owner_name="test-application-cronjob"}'
             value: 900
 
       # assert that the last ran job failed
-      - expr: job:kube_job_status_failed:sum
+      - expr: job:kube_job_status_failed_test_application_dev:sum
         eval_time: 0m
         exp_samples:
-          - labels: 'job:kube_job_status_failed:sum{cronjob="test-application-cronjob", job="test-application-cronjob-2", job_name="test-application-cronjob-2", namespace="test-application-dev", owner_name="test-application-cronjob"}'
+          - labels: 'job:kube_job_status_failed_test_application_dev:sum{cronjob="test-application-cronjob", job="test-application-cronjob-2", job_name="test-application-cronjob-2", namespace="test-application-dev", owner_name="test-application-cronjob"}'
             value: 1
 
     alert_rule_test:
@@ -65,7 +65,6 @@ tests:
               message: CronJob test-application-dev/test-application-cronjob is failing.
               runbook_url: https://runbook.com/application-cronjob-failed
               summary: CronJob is failing.
-
 
   # example two - three jobs (from the same cronjob) have run, the first two failed, the last one succeeded
   - interval: 5m
@@ -99,14 +98,14 @@ tests:
 
     promql_expr_test:
       # assert we're getting the timestamp of the last ran job...
-      - expr: job:kube_job_status_start_time:max
+      - expr: job:kube_job_status_start_time_test_application_dev:max
         eval_time: 0m
         exp_samples:
-          - labels: 'job:kube_job_status_start_time:max{cronjob="test-application-cronjob", job="test-application-cronjob-3", job_name="test-application-cronjob-3", namespace="test-application-dev", owner_name="test-application-cronjob"}'
+          - labels: 'job:kube_job_status_start_time_test_application_dev:max{cronjob="test-application-cronjob", job="test-application-cronjob-3", job_name="test-application-cronjob-3", namespace="test-application-dev", owner_name="test-application-cronjob"}'
             value: 1800
 
       # assert that the last ran job did not fail (we expect nil from the rule)
-      - expr: job:kube_job_status_failed:sum
+      - expr: job:kube_job_status_failed_test_application_dev:sum
         eval_time: 0m
         exp_samples: []
 

--- a/charts/generic-prometheus-alerts/ci/tests/application-alerts-tests.yaml
+++ b/charts/generic-prometheus-alerts/ci/tests/application-alerts-tests.yaml
@@ -1,0 +1,37 @@
+---
+rule_files:
+  - ../application-alerts.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # KubeJobFailed - check that we get an alert on failure
+  - interval: 1m
+    # Series data.
+    input_series:
+      - series: 'up{job="prometheus", instance="localhost:9090"}'
+        values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
+      - series: 'up{job="node_exporter", instance="localhost:9100"}'
+        values: '1+0x6 0 0 0 0 0 0 0 0' # 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0
+      - series: 'go_goroutines{job="prometheus", instance="localhost:9090"}'
+        values: '10+10x2 30+20x5' # 10 20 30 30 50 70 90 110 130
+      - series: 'go_goroutines{job="node_exporter", instance="localhost:9100"}'
+        values: '10+10x7 10+30x4' # 10 20 30 40 50 60 70 80 10 40 70 100 130
+
+    # Unit test for alerting rules.
+    alert_rule_test:
+      # Unit test 1.
+      - eval_time: 10m
+        alertname: InstanceDown
+        exp_alerts:
+          # Alert 1.
+          - exp_labels:
+              severity: page
+              instance: localhost:9090
+              job: prometheus
+            exp_annotations:
+              summary: "Instance localhost:9090 down"
+              description: "localhost:9090 of job prometheus has been down for more than 5 minutes."
+
+
+  # KubeJobFailed - check that alert is cleared after successful run

--- a/charts/generic-prometheus-alerts/templates/application-alerts.yaml
+++ b/charts/generic-prometheus-alerts/templates/application-alerts.yaml
@@ -96,6 +96,48 @@ spec:
           labels:
             severity: {{ .Values.alertSeverity }}
 
+        - record: job:kube_job_status_start_time:max
+          expr: |
+            label_replace(
+              label_replace(
+                max(
+                  kube_job_status_start_time
+                  * ON(job_name,namespace) GROUP_RIGHT()
+                  kube_job_owner{owner_name!=""}
+                )
+                BY (job_name, owner_name, namespace)
+                == ON(owner_name) GROUP_LEFT()
+                max(
+                  kube_job_status_start_time
+                  * ON(job_name,namespace) GROUP_RIGHT()
+                  kube_job_owner{owner_name!=""}
+                )
+                BY (owner_name),
+              "job", "$1", "job_name", "(.+)"),
+            "cronjob", "$1", "owner_name", "(.+)")
+
+        - record: job:kube_job_status_failed:sum
+          expr: |
+            clamp_max(job:kube_job_status_start_time:max,1)
+              * ON(job) GROUP_LEFT()
+              label_replace(
+                label_replace(
+                  (kube_job_status_failed != 0),
+                  "job", "$1", "job_name", "(.+)"),
+                "cronjob", "$1", "owner_name", "(.+)")
+
+        - alert: CronJobStatusFailed
+          annotations:
+            message: CronJob {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.cronjob {{`}}`}} is failing.
+            runbook_url: {{ .Values.runbookUrl }}application-cronjob-failed
+            summary: CronJob is failing.
+          expr: |
+            job:kube_job_status_failed:sum
+            * ON(cronjob,namespace) GROUP_LEFT()
+            (kube_cronjob_spec_suspend == 0)
+          labels:
+            severity: {{ .Values.alertSeverity }}
+
         - alert: KubeJobFailed
           annotations:
             message: Job {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.job_name {{`}}`}} failed to complete.

--- a/charts/generic-prometheus-alerts/templates/application-alerts.yaml
+++ b/charts/generic-prometheus-alerts/templates/application-alerts.yaml
@@ -1,4 +1,5 @@
 {{- $targetNamespace := .Release.Namespace }}
+{{- $targetNamespaceUnderscore := .Release.Namespace | replace "-" "_" }}
 {{- $targetApplication := required "A value for targetApplication must be set" .Values.targetApplication }}
 {{- $targetApplicationRegex := printf "%s.*" .Values.targetApplication }}
 {{- $targetPod := default $targetApplicationRegex .Values.podTargetOverride }}
@@ -96,33 +97,33 @@ spec:
           labels:
             severity: {{ .Values.alertSeverity }}
 
-        - record: job:kube_job_status_start_time:max
+        - record: job:kube_job_status_start_time_{{ $targetNamespaceUnderscore }}:max
           expr: |
             label_replace(
               label_replace(
                 max(
-                  kube_job_status_start_time
+                  kube_job_status_start_time{namespace=~"{{ $targetNamespace }}"}
                   * ON(job_name,namespace) GROUP_RIGHT()
-                  kube_job_owner{owner_name!=""}
+                  kube_job_owner{owner_name!="", namespace=~"{{ $targetNamespace }}"}
                 )
                 BY (job_name, owner_name, namespace)
                 == ON(owner_name) GROUP_LEFT()
                 max(
-                  kube_job_status_start_time
+                  kube_job_status_start_time{namespace=~"{{ $targetNamespace }}"}
                   * ON(job_name,namespace) GROUP_RIGHT()
-                  kube_job_owner{owner_name!=""}
+                  kube_job_owner{owner_name!="", namespace=~"{{ $targetNamespace }}"}
                 )
                 BY (owner_name),
               "job", "$1", "job_name", "(.+)"),
             "cronjob", "$1", "owner_name", "(.+)")
 
-        - record: job:kube_job_status_failed:sum
+        - record: job:kube_job_status_failed_{{ $targetNamespaceUnderscore }}:sum
           expr: |
-            clamp_max(job:kube_job_status_start_time:max,1)
+            clamp_max(job:kube_job_status_start_time_{{ $targetNamespaceUnderscore }}:max,1)
               * ON(job) GROUP_LEFT()
               label_replace(
                 label_replace(
-                  (kube_job_status_failed != 0),
+                  (kube_job_status_failed{namespace=~"{{ $targetNamespace }}"} != 0),
                   "job", "$1", "job_name", "(.+)"),
                 "cronjob", "$1", "owner_name", "(.+)")
 
@@ -132,7 +133,7 @@ spec:
             runbook_url: {{ .Values.runbookUrl }}application-cronjob-failed
             summary: CronJob is failing.
           expr: |
-            job:kube_job_status_failed:sum
+            job:kube_job_status_failed_{{ $targetNamespaceUnderscore }}:sum
             * ON(cronjob,namespace) GROUP_LEFT()
             (kube_cronjob_spec_suspend == 0)
           labels:

--- a/charts/generic-prometheus-alerts/templates/application-alerts.yaml
+++ b/charts/generic-prometheus-alerts/templates/application-alerts.yaml
@@ -27,6 +27,7 @@ spec:
           for: 15m
           labels:
             severity: {{ .Values.alertSeverity }}
+
         - alert: KubePodNotReady
           annotations:
             message: Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} has been in a non-ready state for longer than 15 minutes.
@@ -36,6 +37,7 @@ spec:
           for: 15m
           labels:
             severity: {{ .Values.alertSeverity }}
+
         - alert: KubeDeploymentGenerationMismatch
           annotations:
             message: Deployment generation for {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.deployment {{`}}`}} does not match, this indicates that the Deployment has failed but has not been rolled back.
@@ -48,6 +50,7 @@ spec:
           for: 15m
           labels:
             severity: {{ .Values.alertSeverity }}
+
         - alert: KubeDeploymentReplicasMismatch
           annotations:
             message: Deployment {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.deployment {{`}}`}} has not matched the expected number of replicas for longer 15 minutes.
@@ -60,6 +63,7 @@ spec:
           for: 15m
           labels:
             severity: {{ .Values.alertSeverity }}
+
         - alert: KubeContainerWaiting
           annotations:
             description: Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} container {{`{{`}} $labels.container {{`}}`}} has been in waiting state for longer than 1 hour.
@@ -70,6 +74,7 @@ spec:
           for: 1h
           labels:
             severity: {{ .Values.alertSeverity }}
+
         - alert: KubeCronJobRunning
           annotations:
             message: CronJob {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.cronjob {{`}}`}} is taking more than 1h to complete.
@@ -79,6 +84,7 @@ spec:
           for: 1h
           labels:
             severity: {{ .Values.alertSeverity }}
+
         - alert: KubeJobCompletion
           annotations:
             message: Job {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.job_name {{`}}`}} is taking more than six hours to complete.
@@ -89,6 +95,7 @@ spec:
           for: 6h
           labels:
             severity: {{ .Values.alertSeverity }}
+
         - alert: KubeJobFailed
           annotations:
             message: Job {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.job_name {{`}}`}} failed to complete.
@@ -98,6 +105,7 @@ spec:
           for: 15m
           labels:
             severity: {{ .Values.alertSeverity }}
+
         - alert: KubeHpaReplicasMismatch
           annotations:
             description: HPA {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.hpa {{`}}`}} has not matched the desired number of replicas for longer than 15 minutes.
@@ -120,6 +128,7 @@ spec:
           for: 15m
           labels:
             severity: {{ .Values.alertSeverity }}
+
         - alert: KubeHpaMaxedOut
           annotations:
             description: HPA {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.hpa {{`}}`}} has been running at max replicas for longer than 15 minutes.
@@ -132,6 +141,7 @@ spec:
           for: 15m
           labels:
             severity: {{ .Values.alertSeverity }}
+
         - alert: KubeQuotaExceeded
           annotations:
             message: Namespace {{`{{`}} $labels.namespace {{`}}`}} is using {{`{{`}} printf "%0.0f" $value {{`}}`}}% of its {{`{{`}} $labels.resource {{`}}`}} quota.
@@ -145,6 +155,7 @@ spec:
           for: 15m
           labels:
             severity: {{ .Values.alertSeverity }}
+
         - alert: KubeContainerOOMKilled
           annotations:
             message: "Container {{`{{`}} $labels.container {{`}}`}} in pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} has been OOM Killed (out of memory) {{`{{`}} $value {{`}}`}} times in the last 10 minutes."

--- a/charts/generic-prometheus-alerts/templates/application-alerts.yaml
+++ b/charts/generic-prometheus-alerts/templates/application-alerts.yaml
@@ -139,16 +139,6 @@ spec:
           labels:
             severity: {{ .Values.alertSeverity }}
 
-        - alert: KubeJobFailed
-          annotations:
-            message: Job {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.job_name {{`}}`}} failed to complete.
-            runbook_url: {{ .Values.runbookUrl }}application-job-failed
-            summary: Job failed to complete.
-          expr: kube_job_status_failed{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", job_name=~"{{ $targetJobName }}"} > 0
-          for: 15m
-          labels:
-            severity: {{ .Values.alertSeverity }}
-
         - alert: KubeHpaReplicasMismatch
           annotations:
             description: HPA {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.hpa {{`}}`}} has not matched the desired number of replicas for longer than 15 minutes.

--- a/compile-generic-prometheus-alert-test-app-yaml.sh
+++ b/compile-generic-prometheus-alert-test-app-yaml.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Compiling Chart YAML ..."
+
+CHART_VERSION=$(yq eval '.version' charts/generic-prometheus-alerts/Chart.yaml)
+export CHART_VERSION
+
+cd charts/generic-prometheus-alerts/ci
+
+cd test-application &&
+  envsubst <Chart.tpl.yaml >Chart.yaml &&
+  helm dependency update
+
+cd ..
+
+helm template test-application test-application --dry-run --namespace test-application-dev >compiled-yaml.yaml


### PR DESCRIPTION
This will fix an issue we've seen with false positives [ref PUD-1215] where a job has failed once (from a cron job), but successful runs have completed successfully, but the alert has still persisted.

A major component of this PR is introducing unit tests to the alert rules...