### PR TITLE
Allow prometheus metrics to be served from a custom port

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 1.2.0

--- a/charts/generic-service/templates/deployment.yaml
+++ b/charts/generic-service/templates/deployment.yaml
@@ -53,6 +53,11 @@ spec:
             - name: http
               containerPort: {{ .Values.image.port }}
               protocol: TCP
+            {{- if not (eq (toString .Values.custommetrics.metricsPort) "http") }}
+            - name: metrics
+              containerPort: {{ .Values.custommetrics.metricsPort }}
+              protocol: TCP
+            {{- end }}
           {{- if .Values.livenessProbe }}
           livenessProbe:
 {{ toYaml .Values.livenessProbe | indent 12 }}

--- a/charts/generic-service/templates/servicemonitor.yaml
+++ b/charts/generic-service/templates/servicemonitor.yaml
@@ -10,7 +10,11 @@ spec:
     matchLabels:
       {{- include "generic-service.selectorLabels" . | nindent 6 }}
   endpoints:
+    {{- if not (eq (toString .Values.custommetrics.metricsPort) "http") }}
+    - port: metrics
+    {{- else }}
     - port: http
+    {{- end }}
       interval: {{ .Values.custommetrics.scrapeInterval }}
       path: {{ .Values.custommetrics.metricsPath }}
 {{- end }}

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -127,3 +127,4 @@ custommetrics:
   enabled: false
   scrapeInterval: 15s
   metricsPath: /metrics
+  metricsPort: http


### PR DESCRIPTION
ref: https://mojdt.slack.com/archives/C0223AGGQU8/p1643216466075700

The security team see metrics exposed publicly as an information leakage
vulnerability - this allows teams to serve their metrics on a port
different to the main service so they are no longer exposed as part of
the service outside of the cluster.