### PR TITLE
Bugfix: Fix the ServiceMonitor with a custom metrics port

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.2.1

--- a/charts/generic-service/templates/service.yaml
+++ b/charts/generic-service/templates/service.yaml
@@ -12,6 +12,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if not (eq (toString .Values.custommetrics.metricsPort) "http") }}
+    - port: {{ .Values.service.port | add1 }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+    {{- end }}
   selector:
     {{- include "generic-service.selectorLabels" . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
If the user has defined a custom port for metrics we need to also expose
this port within the service in order for prometheus to pick it up.