### PR TITLE
Condense the "golden signals" dashboards to one per application

### DIFF
--- a/charts/generic-prometheus-alerts/Chart.yaml
+++ b/charts/generic-prometheus-alerts/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/generic-prometheus-alerts/templates/dashboard-golden-signals.yaml
+++ b/charts/generic-prometheus-alerts/templates/dashboard-golden-signals.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.dashboardsEnabled -}}
+{{- if .Release.Namespace | regexMatch "-dev$" -}}
 {{- $targetApplication := required "A value for targetApplication must be set" .Values.targetApplication }}
 {{- $targetIngress := default .Values.targetApplication .Values.ingressTargetOverride }}
 apiVersion: v1
@@ -8,7 +9,7 @@ metadata:
   labels:
     {{- include "generic-prometheus-alerts.dashboardLabels" . | nindent 4 }}
 data:
-  {{ .Release.Namespace }}-{{ $targetApplication }}-golden-signals-dashboard.json: |
+  {{ $targetApplication }}-golden-signals.json: |
     {
       "annotations": {
         "list": [
@@ -28,19 +29,20 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 1,
-      "id": 52,
+      "id": 124,
+      "iteration": 1646224950008,
       "links": [],
       "panels": [
         {
           "aliasColors": {},
-          "bars": false,
+          "bars": true,
           "dashLength": 10,
           "dashes": false,
           "datasource": "Thanos",
           "description": "The number of HTTP requests per second received via the ingress.",
           "fieldConfig": {
             "defaults": {
-              "custom": {}
+              "links": []
             },
             "overrides": []
           },
@@ -63,29 +65,25 @@ data:
             "total": false,
             "values": false
           },
-          "lines": true,
+          "lines": false,
           "linewidth": 2,
           "nullPointMode": "null",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
+          "pluginVersion": "7.5.9",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "stack": false,
+          "stack": true,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(\n  irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"{{ .Release.Namespace }}\"}[1m])\n)",
-              "interval": "",
-              "legendFormat": "Requests",
-              "refId": "A"
-            },
-            {
-              "expr": "sum(\n  irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"{{ .Release.Namespace }}\"}[1m])\n) by (status)",
+              "exemplar": true,
+              "expr": "sum(\n  irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"$namespace\"}[1m])\n) by (status)",
               "interval": "",
               "legendFormat": "{{ "{{status}}" }}",
               "refId": "B"
@@ -111,6 +109,7 @@ data:
           },
           "yaxes": [
             {
+              "$$hashKey": "object:1008",
               "format": "short",
               "label": "Rate Per Second",
               "logBase": 1,
@@ -119,6 +118,7 @@ data:
               "show": true
             },
             {
+              "$$hashKey": "object:1009",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -141,7 +141,7 @@ data:
           "description": "The percentage of HTTP responses that are non-error codes vs error codes.",
           "fieldConfig": {
             "defaults": {
-              "custom": {}
+              "links": []
             },
             "overrides": []
           },
@@ -168,9 +168,10 @@ data:
           "linewidth": 2,
           "nullPointMode": "connected",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
+          "pluginVersion": "7.5.9",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -180,7 +181,8 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"{{ .Release.Namespace }}\", status!~\"5.*|499\"}[1m]))\n/ \nsum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"{{ .Release.Namespace }}\"}[1m]))\n* 100",
+              "exemplar": true,
+              "expr": "sum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"$namespace\", status!~\"5.*|499\"}[1m]))\n/ \nsum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"$namespace\"}[1m]))\n* 100",
               "interval": "",
               "legendFormat": "Request Success Rate",
               "refId": "A"
@@ -206,6 +208,7 @@ data:
           },
           "yaxes": [
             {
+              "$$hashKey": "object:1067",
               "decimals": 0,
               "format": "percent",
               "label": "Percentage",
@@ -215,6 +218,7 @@ data:
               "show": true
             },
             {
+              "$$hashKey": "object:1068",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -237,7 +241,7 @@ data:
           "description": "Recorded request duration from the ingress controllers in percentiles.",
           "fieldConfig": {
             "defaults": {
-              "custom": {}
+              "links": []
             },
             "overrides": []
           },
@@ -264,9 +268,10 @@ data:
           "linewidth": 2,
           "nullPointMode": "connected",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
+          "pluginVersion": "7.5.9",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -276,19 +281,21 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(\n  0.5,\n  max(\n    irate(nginx_ingress_controller_request_duration_seconds_bucket{ingress=\"{{ $targetIngress }}\", exported_namespace=\"{{ .Release.Namespace }}\"}[1m])\n  ) by (le)\n)",
+              "exemplar": true,
+              "expr": "histogram_quantile(\n  0.5,\n  max(\n    irate(nginx_ingress_controller_request_duration_seconds_bucket{ingress=\"{{ $targetIngress }}\", exported_namespace=\"$namespace\"}[1m])\n  ) by (le)\n)",
               "interval": "",
               "legendFormat": "p50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(\n  0.95,\n  max(\n    irate(nginx_ingress_controller_request_duration_seconds_bucket{ingress=\"{{ $targetIngress }}\", exported_namespace=\"{{ .Release.Namespace }}\"}[1m])\n  ) by (le)\n)",
+              "exemplar": true,
+              "expr": "histogram_quantile(\n  0.95,\n  max(\n    irate(nginx_ingress_controller_request_duration_seconds_bucket{ingress=\"{{ $targetIngress }}\", exported_namespace=\"$namespace\"}[1m])\n  ) by (le)\n)",
               "interval": "",
               "legendFormat": "p95",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(\n  1,\n  max(\n    irate(nginx_ingress_controller_request_duration_seconds_bucket{ingress=\"{{ $targetIngress }}\", exported_namespace=\"{{ .Release.Namespace }}\"}[1m])\n  ) by (le)\n)",
+              "expr": "histogram_quantile(\n  1,\n  max(\n    irate(nginx_ingress_controller_request_duration_seconds_bucket{ingress=\"{{ $targetIngress }}\", exported_namespace=\"$namespace\"}[1m])\n  ) by (le)\n)",
               "interval": "",
               "legendFormat": "p100",
               "refId": "C"
@@ -314,6 +321,7 @@ data:
           },
           "yaxes": [
             {
+              "$$hashKey": "object:1120",
               "decimals": null,
               "format": "s",
               "label": "Seconds",
@@ -323,6 +331,7 @@ data:
               "show": true
             },
             {
+              "$$hashKey": "object:1121",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -345,7 +354,7 @@ data:
           "description": "The percentage of all HTTP requests that result in a 5xx status.",
           "fieldConfig": {
             "defaults": {
-              "custom": {}
+              "links": []
             },
             "overrides": []
           },
@@ -372,9 +381,10 @@ data:
           "linewidth": 2,
           "nullPointMode": "connected",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
+          "pluginVersion": "7.5.9",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -384,31 +394,31 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"{{ .Release.Namespace }}\", status=\"500\"}[1m])) \n/ \nsum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"{{ .Release.Namespace }}\"}[5m]))\n* 100",
+              "expr": "sum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"$namespace\", status=\"500\"}[1m])) \n/ \nsum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"$namespace\"}[5m]))\n* 100",
               "interval": "",
               "legendFormat": "500",
               "refId": "A"
             },
             {
-              "expr": "sum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"{{ .Release.Namespace }}\", status=\"501\"}[1m])) \n/ \nsum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"{{ .Release.Namespace }}\"}[5m]))\n* 100",
+              "expr": "sum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"$namespace\", status=\"501\"}[1m])) \n/ \nsum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"$namespace\"}[5m]))\n* 100",
               "interval": "",
               "legendFormat": "501",
               "refId": "B"
             },
             {
-              "expr": "sum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"{{ .Release.Namespace }}\", status=\"502\"}[1m])) \n/ \nsum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"{{ .Release.Namespace }}\"}[5m]))\n* 100",
+              "expr": "sum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"$namespace\", status=\"502\"}[1m])) \n/ \nsum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"$namespace\"}[5m]))\n* 100",
               "interval": "",
               "legendFormat": "502",
               "refId": "C"
             },
             {
-              "expr": "sum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"{{ .Release.Namespace }}\", status=\"503\"}[1m])) \n/ \nsum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"{{ .Release.Namespace }}\"}[5m]))\n* 100",
+              "expr": "sum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"$namespace\", status=\"503\"}[1m])) \n/ \nsum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"$namespace\"}[5m]))\n* 100",
               "interval": "",
               "legendFormat": "503",
               "refId": "D"
             },
             {
-              "expr": "sum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"{{ .Release.Namespace }}\", status=\"504\"}[1m])) \n/ \nsum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"{{ .Release.Namespace }}\"}[5m]))\n* 100",
+              "expr": "sum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"$namespace\", status=\"504\"}[1m])) \n/ \nsum(irate(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\", exported_namespace=\"$namespace\"}[5m]))\n* 100",
               "interval": "",
               "legendFormat": "504",
               "refId": "E"
@@ -434,6 +444,7 @@ data:
           },
           "yaxes": [
             {
+              "$$hashKey": "object:1173",
               "decimals": 0,
               "format": "percent",
               "label": "Percentage",
@@ -443,6 +454,7 @@ data:
               "show": true
             },
             {
+              "$$hashKey": "object:1174",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -465,7 +477,7 @@ data:
           "description": "CPU usage in relation to the requested cpu for the container.",
           "fieldConfig": {
             "defaults": {
-              "custom": {}
+              "links": []
             },
             "overrides": []
           },
@@ -492,9 +504,10 @@ data:
           "linewidth": 2,
           "nullPointMode": "null",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
+          "pluginVersion": "7.5.9",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -504,7 +517,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(irate(container_cpu_usage_seconds_total{pod=~\"{{ $targetApplication }}-.+\", namespace=\"{{ .Release.Namespace }}\"}[1m])) by (container)\n/ \navg(label_replace(kube_pod_container_resource_requests_cpu_cores{pod=~\"{{ $targetApplication }}-.+\", namespace=\"{{ .Release.Namespace }}\"}, \"container_name\", \"$1\", \"container\", \"(.*)\")) by (container)",
+              "expr": "avg(irate(container_cpu_usage_seconds_total{pod=~\"{{ $targetApplication }}-.+\", namespace=\"$namespace\"}[1m])) by (container)\n/ \navg(label_replace(kube_pod_container_resource_requests{resource="cpu", pod=~\"{{ $targetApplication }}-.+\", namespace=\"$namespace\"}, \"container_name\", \"$1\", \"container\", \"(.*)\")) by (container)",
               "hide": false,
               "interval": "",
               "legendFormat": "{{ "{{container}}" }}",
@@ -562,7 +575,7 @@ data:
           "description": "Memory usage in relation to the requested memory for the container.",
           "fieldConfig": {
             "defaults": {
-              "custom": {}
+              "links": []
             },
             "overrides": []
           },
@@ -589,9 +602,10 @@ data:
           "linewidth": 2,
           "nullPointMode": "null",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
+          "pluginVersion": "7.5.9",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -601,7 +615,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(irate(container_memory_usage_bytes{pod=~\"{{ $targetApplication }}-.+\", namespace=\"{{ .Release.Namespace }}\"}[1m])) by (container)\n/ \navg(kube_pod_container_resource_requests_memory_bytes{pod=~\"{{ $targetApplication }}-.+\", namespace=\"{{ .Release.Namespace }}\"}) by (container)\n* 100",
+              "expr": "avg(irate(container_memory_usage_bytes{pod=~\"{{ $targetApplication }}-.+\", namespace=\"$namespace\"}[1m])) by (container)\n/ \navg(kube_pod_container_resource_requests{resource="memory", pod=~\"{{ $targetApplication }}-.+\", namespace=\"$namespace\"}) by (container)\n* 100",
               "hide": false,
               "interval": "",
               "legendFormat": "{{ "{{container}}" }}",
@@ -659,7 +673,7 @@ data:
           "description": "The number of available pod replicas for the service.",
           "fieldConfig": {
             "defaults": {
-              "custom": {}
+              "links": []
             },
             "overrides": []
           },
@@ -686,9 +700,10 @@ data:
           "linewidth": 2,
           "nullPointMode": "null",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
+          "pluginVersion": "7.5.9",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -698,7 +713,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "count(\n  label_replace(kube_pod_info{pod=~\"{{ $targetApplication }}-.+\", namespace=\"{{ .Release.Namespace }}\"}, \"pod\", \"$1\", \"created_by_name\", \"(.*)-\\\\w+\")\n) by (pod)",
+              "expr": "count(\n  label_replace(kube_pod_info{pod=~\"{{ $targetApplication }}-.+\", namespace=\"$namespace\"}, \"pod\", \"$1\", \"created_by_name\", \"(.*)-\\\\w+\")\n) by (pod)",
               "interval": "",
               "legendFormat": "{{ "{{pod}}" }}",
               "refId": "B"
@@ -755,7 +770,7 @@ data:
           "description": "Average recorded CPU usage for each type container within the pods.",
           "fieldConfig": {
             "defaults": {
-              "custom": {}
+              "links": []
             },
             "overrides": []
           },
@@ -782,9 +797,10 @@ data:
           "linewidth": 2,
           "nullPointMode": "null",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
+          "pluginVersion": "7.5.9",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -794,7 +810,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(\n  irate(container_cpu_usage_seconds_total{pod=~\"{{ $targetApplication }}-.+\", namespace=\"{{ .Release.Namespace }}\", container!=\"POD\", container=~\".+\"}[1m])\n) by (container)",
+              "expr": "avg(\n  irate(container_cpu_usage_seconds_total{pod=~\"{{ $targetApplication }}-.+\", namespace=\"$namespace\", container!=\"POD\", container=~\".+\"}[1m])\n) by (container)",
               "hide": false,
               "interval": "",
               "legendFormat": "{{ "{{container}}" }}",
@@ -852,7 +868,7 @@ data:
           "description": "Average recorded memory usage for a single type of container within the pods.",
           "fieldConfig": {
             "defaults": {
-              "custom": {}
+              "links": []
             },
             "overrides": []
           },
@@ -879,9 +895,10 @@ data:
           "linewidth": 2,
           "nullPointMode": "null",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
+          "pluginVersion": "7.5.9",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -891,7 +908,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(\n  irate(container_memory_usage_bytes{pod=~\"{{ $targetApplication }}-.+\", namespace=\"{{ .Release.Namespace }}\", container!=\"POD\", container=~\".+\"}[1m])\n) by (container)",
+              "expr": "avg(\n  irate(container_memory_usage_bytes{pod=~\"{{ $targetApplication }}-.+\", namespace=\"$namespace\", container!=\"POD\", container=~\".+\"}[1m])\n) by (container)",
               "hide": false,
               "interval": "",
               "legendFormat": "{{ "{{container}}" }}",
@@ -949,7 +966,7 @@ data:
           "description": "The amount of data being sent to and from the pods.",
           "fieldConfig": {
             "defaults": {
-              "custom": {}
+              "links": []
             },
             "overrides": []
           },
@@ -976,9 +993,10 @@ data:
           "linewidth": 2,
           "nullPointMode": "null",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
+          "pluginVersion": "7.5.9",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -993,13 +1011,13 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(container_network_receive_bytes_total{namespace=\"{{ .Release.Namespace }}\", pod=~\"{{ $targetApplication }}-.+\"}[2m]))",
+              "expr": "sum(irate(container_network_receive_bytes_total{namespace=\"$namespace\", pod=~\"{{ $targetApplication }}-.+\"}[2m]))",
               "interval": "",
               "legendFormat": "Receive",
               "refId": "A"
             },
             {
-              "expr": "sum(irate(container_network_transmit_bytes_total{namespace=\"{{ .Release.Namespace }}\", pod=~\"{{ $targetApplication }}-.+\"}[2m]))",
+              "expr": "sum(irate(container_network_transmit_bytes_total{namespace=\"$namespace\", pod=~\"{{ $targetApplication }}-.+\"}[2m]))",
               "interval": "",
               "legendFormat": "Transmit",
               "refId": "C"
@@ -1048,11 +1066,43 @@ data:
           }
         }
       ],
-      "schemaVersion": 25,
+      "schemaVersion": 27,
       "style": "dark",
       "tags": {{ include "generic-prometheus-alerts.dashboardTags" . }},
       "templating": {
-        "list": []
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "selected": true,
+              "text": "{{ .Release.Namespace }}",
+              "value": "{{ .Release.Namespace }}"
+            },
+            "datasource": null,
+            "definition": "label_values(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\"}, exported_namespace)",
+            "description": null,
+            "error": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": {
+              "query": "label_values(nginx_ingress_controller_requests{ingress=\"{{ $targetIngress }}\"}, exported_namespace)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
       },
       "time": {
         "from": "now-1h",
@@ -1083,8 +1133,9 @@ data:
         ]
       },
       "timezone": "browser",
-      "title": "{{ .Release.Namespace }} / {{ .Release.Name }} / Golden Signals",
+      "title": "{{ .Release.Name }} / Golden Signals",
       "uid": "{{ include "generic-prometheus-alerts.dashboardUIDPrefix" . }}-gs",
       "version": 1
     }
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
Originally we set them up as one per application/namespace, but that's
now meaning a **lot** of dashboards in grafana. This change adds in a
variable (to the grafana dashboard) for the namespace so we can go from
3 to 1 dashboard per deployed application.