### PR TITLE
DCS-1515: ⬇️ rollback generic-data-analytics-extractor apiVersion to batch/v1beta1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ charts/generic-prometheus-alerts/ci/ingress-alerts.yaml
 charts/generic-prometheus-alerts/ci/test-application/Chart.lock
 charts/generic-prometheus-alerts/ci/test-application/Chart.yaml
 charts/generic-prometheus-alerts/ci/test-application/charts
+
+.idea

--- a/charts/generic-data-analytics-extractor/templates/cronjob.yaml
+++ b/charts/generic-data-analytics-extractor/templates/cronjob.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.enabled -}}
-apiVersion: batch/v1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-data-analytics-extractor


### PR DESCRIPTION
Getting an error with our [current deployment of this](https://app.circleci.com/pipelines/github/ministryofjustice/use-of-force/3028/workflows/8db17aee-28f3-4252-9f45-364aea0b287a/jobs/9297)

Not entirely sure it's related to the apiVersion, but the other cronjob deployed in this repo uses the batch/v1beta1. This will be deprecated when we get to Kubernetes version 1.25 but since we're not close to that yet we'll live with the warning for now and cross the migration bridge when we come to it