### PR TITLE
allow-subject-alternative-names-to-get-around-domain-length-limit

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.0
+version: 1.7.0

--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.0
+version: 2.0.0

--- a/charts/generic-service/README.md
+++ b/charts/generic-service/README.md
@@ -152,7 +152,8 @@ generic-service:
   replicaCount: 2
 
   ingress:
-    host: project-name-dev.hmpps.service.justice.gov.uk
+    hosts:
+      - project-name-dev.hmpps.service.justice.gov.uk
 ```
 
 ### Prison Postgres database restore cronjob

--- a/charts/generic-service/templates/ingress.yaml
+++ b/charts/generic-service/templates/ingress.yaml
@@ -26,7 +26,7 @@ spec:
   - hosts:
     {{- range .Values.ingress.hosts }}
     - {{ . }}
-    {{- end }}  
+    {{- end }}
     {{ if .Values.ingress.tlsSecretName }}secretName: {{ .Values.ingress.tlsSecretName }}{{ end }}
   rules:
     {{- range .Values.ingress.hosts }}

--- a/charts/generic-service/templates/ingress.yaml
+++ b/charts/generic-service/templates/ingress.yaml
@@ -1,6 +1,7 @@
 {{- if and .Values.ingress.enabled .Values.ingress.v0_47_enabled -}}
 {{- $fullName := include "generic-service.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
+{{- $ingressPath  := .Values.ingress.path -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -24,6 +25,10 @@ metadata:
 spec:
   tls:
   - hosts:
+      - https-example.foo.com
+    secretName: testsecret-tls
+  tls:
+  - hosts:
     {{- range .Values.ingress.hosts }}
     - {{ . }}
     {{- end }}
@@ -33,12 +38,12 @@ spec:
     - host: {{ . }}
       http:
         paths:
-          - path: {{ .Values.ingress.path }}
+          - path: {{ $ingressPath }}
             pathType: ImplementationSpecific
             backend:
               service:
                 name: {{ $fullName }}
                 port:
-                  number: {{ .Values.service.port }}
+                  number: {{ $svcPort }}
     {{- end }}
 {{- end }}

--- a/charts/generic-service/templates/ingress.yaml
+++ b/charts/generic-service/templates/ingress.yaml
@@ -25,12 +25,8 @@ metadata:
 spec:
   tls:
   - hosts:
-      - https-example.foo.com
-    secretName: testsecret-tls
-  tls:
-  - hosts:
     {{- range .Values.ingress.hosts }}
-    - {{ . }}
+      - {{ . }}
     {{- end }}
     {{ if .Values.ingress.tlsSecretName }}secretName: {{ .Values.ingress.tlsSecretName }}{{ end }}
   rules:

--- a/charts/generic-service/templates/ingress.yaml
+++ b/charts/generic-service/templates/ingress.yaml
@@ -24,10 +24,13 @@ metadata:
 spec:
   tls:
   - hosts:
-    - {{ .Values.ingress.host }}
+    {{- range .Values.ingress.hosts }}
+    - {{ . }}
+    {{- end }}  
     {{ if .Values.ingress.tlsSecretName }}secretName: {{ .Values.ingress.tlsSecretName }}{{ end }}
   rules:
-    - host: {{ .Values.ingress.host }}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
       http:
         paths:
           - path: {{ .Values.ingress.path }}
@@ -37,4 +40,5 @@ spec:
                 name: {{ $fullName }}
                 port:
                   number: {{ .Values.service.port }}
+    {{- end }}
 {{- end }}

--- a/charts/generic-service/templates/ingress_v1_2.yaml
+++ b/charts/generic-service/templates/ingress_v1_2.yaml
@@ -25,10 +25,13 @@ spec:
   ingressClassName: {{- if .Values.ingress.modsecurity_enabled }} "modsec" {{- else }} "default" {{- end }}
   tls:
   - hosts:
-    - {{ .Values.ingress.host }}
+    {{- range .Values.ingress.hosts }}
+    - {{ . }}
+    {{- end }}
     {{ if .Values.ingress.tlsSecretName }}secretName: {{ .Values.ingress.tlsSecretName }}{{ end }}
   rules:
-    - host: {{ .Values.ingress.host }}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
       http:
         paths:
           - path: {{ .Values.ingress.path }}
@@ -38,4 +41,5 @@ spec:
                 name: {{ $fullName }}
                 port:
                   number: {{ .Values.service.port }}
+    {{- end }}
 {{- end }}

--- a/charts/generic-service/templates/ingress_v1_2.yaml
+++ b/charts/generic-service/templates/ingress_v1_2.yaml
@@ -2,6 +2,7 @@
 {{- $fullName := include "generic-service.fullname" . -}}
 {{- $ingressName := print $fullName "-v1-2" }}
 {{- $svcPort := .Values.service.port -}}
+{{- $ingressPath  := .Values.ingress.path -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -34,12 +35,12 @@ spec:
     - host: {{ . }}
       http:
         paths:
-          - path: {{ .Values.ingress.path }}
+          - path: {{ $ingressPath }}
             pathType: ImplementationSpecific
             backend:
               service:
                 name: {{ $fullName }}
                 port:
-                  number: {{ .Values.service.port }}
+                  number: {{ $svcPort }}
     {{- end }}
 {{- end }}

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -50,7 +50,8 @@ ingress:
   v0_47_enabled: true
   annotations:
     nginx.ingress.kubernetes.io/custom-http-errors: "418"
-  host: chart-example.local
+  hosts: 
+    - chart-example.local
   path: /
   tlsSecretName: chart-example-tls
   modsecurity_enabled: false

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -50,7 +50,7 @@ ingress:
   v0_47_enabled: true
   annotations:
     nginx.ingress.kubernetes.io/custom-http-errors: "418"
-  hosts: 
+  hosts:
     - chart-example.local
   path: /
   tlsSecretName: chart-example-tls


### PR DESCRIPTION
allow subject alternative names to get around domain length limit that results in the certificate being unable to renew.

if an ingress.host is longer than 64 chars then a cert is generated with that CN. Having a CN longer than 64 chars causes the cert to not be accepted. If there are multiple tls.hosts (one becomes a CN and the others SANs), if one is less than 64 chars it will be chosen as the CN and the cert will be good