### PR TITLE
Bump versions for GitHub actions and Helm; small readme tidyups

### DIFF
--- a/.github/workflows/alert-test.yml
+++ b/.github/workflows/alert-test.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
-          version: v3.4.0
+          version: v3.10.2
 
       - name: Install yq
         uses: chrisdickinson/setup-yq@latest

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           changed=$(ct list-changed --config .github/config/ct.yaml)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "name=changed::true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -7,21 +7,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
-          version: v3.4.0
+          version: v3.10.2
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
+        uses: helm/chart-testing-action@v2.3.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -37,7 +37,7 @@ jobs:
       # Uncomment below to enable testing install of charts
 
       #- name: Create kind cluster
-      #  uses: helm/kind-action@v1.0.0
+      #  uses: helm/kind-action@v1.4.0
       #  if: steps.list-changed.outputs.changed == 'true'
 
       #- name: Run chart-testing (install)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -20,11 +20,11 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
-          version: v3.4.0
+          version: v3.10.2
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.0
+        uses: helm/chart-releaser-action@v1.4.1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Here you will find a common place for helm charts used by HMPPS projects/services.
 ([Click here][version_list] to see which services use them.)
 
-The charts are built and published via github actions and github pages, see <https://github.com/helm/chart-releaser>
+The charts are built and published via GitHub Actions and GitHub pages, see <https://github.com/helm/chart-releaser>
 
 ## Quick start
 
@@ -63,7 +63,7 @@ helm -n my-namespace template <release-name> <directory-containing-project-chart
 
 ## Unit Testing Prometheus Alerts
 
-To run the unit tests you will need both [yq], envsubst and promtool installed, these can be installed on a mac via homebrew:
+To run the unit tests you will need [yq], envsubst, and promtool installed, these can be installed on a Mac via homebrew:
 
 ```shell
 brew install yq prometheus gettext
@@ -75,9 +75,7 @@ Then simply run the following to run the unit tests:
 make test
 ```
 
-More information on how to write a prometheus rule unit test can be found on the prometheus website:
-
-https://www.prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/
+More information on how to write a Prometheus rule unit test can be found on the Prometheus docs, see <https://www.prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/>
 
 [version_list]: https://structurizr.com/share/56937/documentation/*#2
-[yq]: http://mikefarah.github.io/yq/
+[yq]: https://mikefarah.gitbook.io/yq/

--- a/charts/generic-prometheus-alerts/RUNBOOK.md
+++ b/charts/generic-prometheus-alerts/RUNBOOK.md
@@ -24,7 +24,7 @@ The best course of action is to check the application and ingress logs and inves
 
 ### ingress-modsecurity-blocking
 
-> Mod_Security is blocking ingress `<namespace>`/`<service>`. Blocking http requests at rate of `<rate>` per minute.
+> Mod_Security is blocking ingress `<namespace>`/`<service>`. Blocking http requests at rate of `<rate>` per second.
 
 The modsecurity module (part of the NGINX ingress) has been blocking requests to your application at an elevated rate for over 1 minute. This is most likely due to the modsecurity rules detecting what it deem malicious requests.
 
@@ -140,6 +140,8 @@ Your application container is using more memory than it's currently configured t
 
 If your application genuinely needs more memory you can either set memory requests and limits in your application helm chart - this will affect only your container/pod - or you can also increase the default requests and limits for all pods in your namespace by editing the `limitrange` in your namespace (via [cloud-platform-environments](https://github.com/ministryofjustice/cloud-platform-environments)).
 
+## RDS Alerts
+
 ### rds-cpu-utilisation
 
 > RDS database `<database>` in `<namespace>` - CPU utilisation at `XX` which is over threshold of `YY` for last 5 mins.
@@ -173,9 +175,11 @@ The alert should be configured so that it alerts for about 80% utilisation, so i
 Other reasons why you could run out is if perhaps you're running r2dbc and you've got a connection leak caused by a
 [bug](https://github.com/r2dbc/r2dbc-pool/issues/165).
 
+## SQS Alerts
+
 ### sqs-oldest-message
 
-> SQS - {{ $sqsLabelQueueName }} has message older than {{ $sqsAlertsOldestThreshold }}mins, check consumers are healthy. This alert configured by app {{ $targetNamespace }}/{{ $targetApplication }}.
+> SQS - {{ $sqsLabelQueueName }} has message older than {{ $sqsAlertsOldestThreshold }} mins, check consumers are healthy. This alert configured by app {{ $targetNamespace }}/{{ $targetApplication }}.
 
 ### sqs-number-of-messages
 


### PR DESCRIPTION
I saw in the GitHub actions for the previous PR - https://github.com/ministryofjustice/hmpps-helm-charts/pull/79 that there were some warnings
- https://github.com/ministryofjustice/hmpps-helm-charts/actions/runs/3647711421
- https://github.com/ministryofjustice/hmpps-helm-charts/actions/runs/3647711418

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, azure/setup-helm@v1, chrisdickinson/setup-yq@latest

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/