### PR TITLE
PIC 3363 k8s upgrade removing deprecated APIs

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.7.2
+version: 2.7.3

--- a/charts/generic-service/templates/hpa.yaml
+++ b/charts/generic-service/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "generic-service.fullname" . }}


### PR DESCRIPTION
In lieu of : 

https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/apiversion-changes-hpa-k8s-1-25.html#updating-horizontalpodautoscaler-api-version-for-cloud-platform-removed-kubernetes-v1-25

- Upgrade Horizontal Pod Autoscaler version in hpa.yaml
- Bump version number