### PR TITLE
RR-446 - Add nameOverride to generic-data-analytics-extractor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea/
+
 charts/generic-prometheus-alerts/ci/test-*/Chart.lock
 charts/generic-prometheus-alerts/ci/test-*/Chart.yaml
 charts/generic-prometheus-alerts/ci/test-*/charts

--- a/README.md
+++ b/README.md
@@ -57,13 +57,30 @@ helm dependency update <directory-containing-project-chart>
 Then can run a dry-run upgrade to see the effect:
 
 ```bash
-helm upgrade --dry-run --namespace my-namespace <release-name> <directory-containing-project-chart> --values=<values-file>
+helm upgrade \
+  --dry-run \
+  --namespace my-namespace \ 
+  --values=<values-file> \
+  <release-name> \
+  <directory-containing-project-chart> 
 ```
-
+for example:
+```bash
+helm upgrade \
+  --dry-run \
+  --namespace hmpps-education-and-work-plan-dev \
+  --values ./helm_deploy/values-dev.yaml \
+  hmpps-education-and-work-plan-api \
+  ./helm_deploy/hmpps-education-and-work-plan-api
+```
 You can also compare the template yaml by running the following both before and after your changes, saving the output to files:
 
 ```bash
-helm template --namespace my-namespace <release-name> <directory-containing-project-chart> --values=<values-file>
+helm template \
+  --namespace my-namespace \
+  --values=<values-file> \
+  <release-name> \
+  <directory-containing-project-chart>
 ```
 
 ## Unit Testing Prometheus Alerts

--- a/charts/generic-data-analytics-extractor/Chart.yaml
+++ b/charts/generic-data-analytics-extractor/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: generic-data-analytics-extractor
 description: Runs a daily cron job which extracts and sends a database dump to the analytical platform
-version: 1.1.0
+version: 1.1.1

--- a/charts/generic-data-analytics-extractor/README.md
+++ b/charts/generic-data-analytics-extractor/README.md
@@ -51,3 +51,11 @@ generic-data-analytics-extractor:
 ```
 
 Available scripts provided by the docker image can ber found in the [ministryofjustice/data-engineering-data-extractor](https://github.com/ministryofjustice/data-engineering-data-extractor) repo.
+
+## Support
+This helm chart was created by the HMPPS Dev teams as a convenience to make use of the Data Engineering tools to extract
+data and send to the Analytical Platform.  
+Whilst the docker image that the cron job uses was written by the Data Engineering team, this helm chart was created by
+the HMPPS Dev teams.  
+Any questions regarding the use and configuration of this helm chart should be posted on the [#hmpps_dev](https://moj.enterprise.slack.com/archives/C69NWE339)
+slack channel in the first instance.

--- a/charts/generic-data-analytics-extractor/templates/_helpers.tpl
+++ b/charts/generic-data-analytics-extractor/templates/_helpers.tpl
@@ -17,3 +17,17 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Expand the name of the chart.
+The maximum length of the resource name is 52.
+If an overridden name is provided it will be truncated at 52
+If the default name is to be used it is made up of the release name (truncated to 27) and `-data-analytics-extractor` giving a maximum length of 52.
+*/}}
+{{- define "generic-data-analytics-extractor.name" -}}
+{{- if .Values.nameOverride -}}
+{{- .Values.nameOverride | trunc 52 -}}
+{{- else -}}
+{{ .Release.Name | trunc 27 -}}-data-analytics-extractor
+{{- end -}}
+{{- end -}}

--- a/charts/generic-data-analytics-extractor/templates/_helpers.tpl
+++ b/charts/generic-data-analytics-extractor/templates/_helpers.tpl
@@ -19,14 +19,15 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
-Expand the name of the chart.
-The maximum length of the resource name is 52.
-If an overridden name is provided it will be truncated at 52
-If the default name is to be used it is made up of the release name (truncated to 27) and `-data-analytics-extractor` giving a maximum length of 52.
+Returns the name of the cronjob resource.
+Cronjob resource names have a maximum length of 52 characters - see https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#:~:text=Even%20when%20the%20name%20is,no%20more%20than%2063%20characters
+
+The default behaviour is to use the release name (truncated to 27) appended with `-data-analytics-extractor` giving a maximum length of 52.
+This behaviour can be overriden by providing a `cronJobNameOverride`. If provided in the values it will be used, truncated at 52.
 */}}
-{{- define "generic-data-analytics-extractor.name" -}}
-{{- if .Values.nameOverride -}}
-{{- .Values.nameOverride | trunc 52 -}}
+{{- define "generic-data-analytics-extractor.cronjob-name" -}}
+{{- if .Values.cronJobNameOverride -}}
+{{- .Values.cronJobNameOverride | trunc 52 -}}
 {{- else -}}
 {{ .Release.Name | trunc 27 -}}-data-analytics-extractor
 {{- end -}}

--- a/charts/generic-data-analytics-extractor/templates/cronjob.yaml
+++ b/charts/generic-data-analytics-extractor/templates/cronjob.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "generic-data-analytics-extractor.name" . }}
+  name: {{ include "generic-data-analytics-extractor.cronjob-name" . }}
   labels:
     app: {{ template "app.fullname" . }}
     release: {{ .Release.Name }}

--- a/charts/generic-data-analytics-extractor/templates/cronjob.yaml
+++ b/charts/generic-data-analytics-extractor/templates/cronjob.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}-data-analytics-extractor
+  name: {{ include "generic-data-analytics-extractor.name" . }}
   labels:
     app: {{ template "app.fullname" . }}
     release: {{ .Release.Name }}

--- a/charts/generic-data-analytics-extractor/templates/cronjob.yaml
+++ b/charts/generic-data-analytics-extractor/templates/cronjob.yaml
@@ -58,14 +58,16 @@ spec:
                     secretKeyRef:
                       name: {{ $destinationS3SecretName }}
                       key: {{ .Values.destinationS3SecretKey }}
-                - name: API_AUTH
-                  valueFrom:
-                    secretKeyRef:
-                      name: {{ .Values.dataPlatformApiAuthSecretName }}
-                      key: {{ .Values.dataPlatformApiAuthSecretKey }}
                 - name: AWS_DEFAULT_REGION
                   value: "{{ .Values.awsDefaultRegion }}"
                 - name: SAVE_EVENTS_LOG
                   value: "{{ .Values.saveEventsLog }}"
                 - name: DATA_PRODUCT_NAME
                   value: "{{ .Values.dataProductName }}"
+{{- if .Values.dataPlatformApiAuthSecretName }}
+                - name: API_AUTH
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.dataPlatformApiAuthSecretName }}
+                      key: {{ .Values.dataPlatformApiAuthSecretKey }}
+{{- end }}

--- a/charts/generic-data-analytics-extractor/values.yaml
+++ b/charts/generic-data-analytics-extractor/values.yaml
@@ -25,7 +25,7 @@ databaseNameSecretKey: database_name
 databaseUsernameSecretKey: database_username
 databasePasswordSecretKey: database_password
 
-# Required: set to the name of secret where API auth creds are stored.
+# Optional: set to the name of secret where API auth creds are stored.
 dataPlatformApiAuthSecretName: ""
 dataPlatformApiAuthSecretKey: auth-key
 
@@ -33,7 +33,7 @@ dataPlatformApiAuthSecretKey: auth-key
 # a registered data product
 dataProductName: ""
 
-# Optional chart name override. The default is the release name (truncated to 27) followed by `-data-analytics-extractor`
+# Optional: chart name override. The default is the release name (truncated to 27) followed by `-data-analytics-extractor`
 nameOverride: ""
 
 fullnameOverride: ""

--- a/charts/generic-data-analytics-extractor/values.yaml
+++ b/charts/generic-data-analytics-extractor/values.yaml
@@ -33,8 +33,8 @@ dataPlatformApiAuthSecretKey: auth-key
 # a registered data product
 dataProductName: ""
 
-# Optional: chart name override. The default is the release name (truncated to 27) followed by `-data-analytics-extractor`
-nameOverride: ""
+# Optional: Cronjob resource name override. The default cronjob name is the release name (truncated to 27) followed by `-data-analytics-extractor`
+cronJobNameOverride: ""
 
 fullnameOverride: ""
 

--- a/charts/generic-data-analytics-extractor/values.yaml
+++ b/charts/generic-data-analytics-extractor/values.yaml
@@ -33,6 +33,11 @@ dataPlatformApiAuthSecretKey: auth-key
 # a registered data product
 dataProductName: ""
 
+# Optional chart name override. The default is the release name (truncated to 27) followed by `-data-analytics-extractor`
+nameOverride: ""
+
+fullnameOverride: ""
+
 image:
   repository: ministryofjustice/data-engineering-data-extractor
   tag: v1.2.2


### PR DESCRIPTION
This PR comes about after trying to use the `generic-data-analytics-extractor` helm chart in the `hmpps-education-and-work-plan-api` project.

### Problem
The problem it solves is that of the generated name, which in the original code is this:
```
kind: CronJob
metadata:
  name: {{ .Release.Name }}-data-analytics-extractor
  labels:
```
The name is simply a concatenation of the release name and `-data-analytics-extractor` which for our project resulted in `hmpps-education-and-work-plan-api-data-analytics-extractor`. This this fails to deploy as the resource name is limited at 52 characters:
> Error: UPGRADE FAILED: failed to create resource: CronJob.batch "hmpps-education-and-work-plan-api-data-analytics-extractor" is invalid: [spec.jobTemplate.spec.template.spec.containers[0].env[5].valueFrom.secretKeyRef.name: Invalid value: "": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'), metadata.name: Invalid value: "hmpps-education-and-work-plan-api-data-analytics-extractor": must be no more than 52 characters]

### Fix
There are 2 parts to this fix. The first is to use a truncated version of the release name, truncated at 27 characters. Therefore the resultant name using our project would be `hmpps-education-and-work-pl-data-analytics-extractor`
The second part of the fix is to allow an optional `nameOverride` value to be passed in which will be used instead of the generated one.

### Other
The Data Engineering team have been helping me implement and use the data analytics extractor tool in our project, and it was them who pointed me at this chart in the first place. On discovering the problem with the name I looked to them for help, assuming that this helm chart had come from their team.
They helped where they could, but asked me to add the comment to the `readme` explaining that queries regarding the use and configuration of the helm chart itself should probably be directed to the #hmpps_dev slack channel in the first instance.
