### PR TITLE
CPR-142 add retry dlq cronjob with support for scheduled downtime

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.9.2
+version: 2.10.1

--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.10.1
+version: 2.9.3

--- a/charts/generic-service/README.md
+++ b/charts/generic-service/README.md
@@ -246,3 +246,23 @@ scheduledDowntime:
   shutdown: '0 22 * * 1-5' # Stop at 10pm UTC Monday-Friday
   serviceAccountName: scheduled-downtime-serviceaccount # This must match the service account name in the Terraform module
 ```
+
+### Retrying messages on a dead letter queue
+
+The [hmpps-spring-boot-sqs](https://github.com/ministryofjustice/hmpps-spring-boot-sqs/?tab=readme-ov-file#usage) project provides an endpoint for retrying all messages on all dead letter queues. Setting the following value will add a cronjob to your service which will call the retry endpoint every 10 minutes. 
+
+```yaml
+---
+retryDlqCronjob:
+  enabled: true
+  retryDlqSchedule: "*/20 * * * *" # only set this if you want to override the default schedule of every 10 minutes
+```
+
+If you have configured scheduled downtime, the cronjob will not run during the downtime
+Again, you can override the default cron schedule when scheduled downtime is enabled:
+
+```yaml
+---
+scheduledDowntime:
+  retryDlqSchedule: "*/45 * * * 1-3"
+```

--- a/charts/generic-service/templates/retry-dlq-cronjob.yaml
+++ b/charts/generic-service/templates/retry-dlq-cronjob.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "generic-service.fullname" . | trunc 26 }}-queue-housekeeping-cronjob
+  name: {{ include "generic-service.fullname" . | trunc 26 }}-retry-dlqs
   labels:
     {{- include "generic-service.labels" . | nindent 4 }}
 spec:

--- a/charts/generic-service/templates/retry-dlq-cronjob.yaml
+++ b/charts/generic-service/templates/retry-dlq-cronjob.yaml
@@ -19,9 +19,6 @@ spec:
     spec:
       template:
         spec:
-          {{- if .Values.serviceAccountName }}
-          serviceAccountName: {{ .Values.serviceAccountName }}
-          {{- end }}
           containers:
             - name: housekeeping
               image: ghcr.io/ministryofjustice/hmpps-devops-tools

--- a/charts/generic-service/templates/retry-dlq-cronjob.yaml
+++ b/charts/generic-service/templates/retry-dlq-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
         spec:
           containers:
             - name: retry-all-dlqs
-              image: ghcr.io/ministryofjustice/hmpps-devops-tools
+              image: "{{ .Values.retryDlqCronjob.image }}:{{ .Values.retryDlqCronjob.tag }}"
               args:
                 - /bin/sh
                 - -c

--- a/charts/generic-service/templates/retry-dlq-cronjob.yaml
+++ b/charts/generic-service/templates/retry-dlq-cronjob.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.retryDlqCronjob.enabled -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "generic-service.fullname" . | trunc 26 }}-queue-housekeeping-cronjob
+  labels:
+    {{- include "generic-service.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.scheduledDowntime.enabled }}
+  schedule: "{{ .Values.scheduledDowntime.retryDlqSchedule }}"
+  {{- else }}
+  schedule: "*/10 * * * *"
+  {{- end }}
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 600
+  successfulJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          {{- if .Values.serviceAccountName }}
+          serviceAccountName: {{ .Values.serviceAccountName }}
+          {{- end }}
+          containers:
+            - name: housekeeping
+              image: ghcr.io/ministryofjustice/hmpps-devops-tools
+              args:
+                - /bin/sh
+                - -c
+                - curl -XPUT --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 http://{{ include "generic-service.fullname" . }}/queue-admin/retry-all-dlqs
+          restartPolicy: Never
+  {{- end}}

--- a/charts/generic-service/templates/retry-dlq-cronjob.yaml
+++ b/charts/generic-service/templates/retry-dlq-cronjob.yaml
@@ -9,7 +9,7 @@ spec:
   {{- if .Values.scheduledDowntime.enabled }}
   schedule: "{{ .Values.scheduledDowntime.retryDlqSchedule }}"
   {{- else }}
-  schedule: "*/10 * * * *"
+  schedule: "{{ .Values.retryDlqCronjob.retryDlqSchedule }}"
   {{- end }}
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 5

--- a/charts/generic-service/templates/retry-dlq-cronjob.yaml
+++ b/charts/generic-service/templates/retry-dlq-cronjob.yaml
@@ -20,7 +20,7 @@ spec:
       template:
         spec:
           containers:
-            - name: housekeeping
+            - name: retry-all-dlqs
               image: ghcr.io/ministryofjustice/hmpps-devops-tools
               args:
                 - /bin/sh

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -226,3 +226,5 @@ retryDlqCronjob:
   enabled: false
   # every 10 minutes
   retryDlqSchedule: "*/10 * * * *"
+  image: ghcr.io/ministryofjustice/hmpps-devops-tools
+  tag: latest

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -224,4 +224,5 @@ scheduledDowntime:
 
 retryDlqCronjob:
   enabled: false
-
+  # every 10 minutes
+  retryDlqSchedule: "*/10 * * * *"

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -219,3 +219,9 @@ scheduledDowntime:
   # Stop at 10pm UTC Monday-Friday
   shutdown: '0 22 * * 1-5'
   serviceAccountName: scheduled-downtime-serviceaccount
+  # every 10 minutes between 7am and 10pm UTC Monday-Friday
+  retryDlqSchedule: "*/10 7-21 * * 1-5"
+
+retryDlqCronjob:
+  enabled: false
+


### PR DESCRIPTION
This is the output with `retryDlqCronjob` and `scheduledDowntime` enabled

```# Source: hmpps-person-record/charts/generic-service/templates/retry-dlq-cronjob.yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  name: hmpps-person-record-queue-housekeeping-cronjob
  labels:
    helm.sh/chart: generic-service-2.10.1
    app: hmpps-person-record
    release: hmpps-person-record
    app.kubernetes.io/version: "latest"
    app.kubernetes.io/managed-by: Helm
spec:
  schedule: "*/10 7-21 * * 1-5"
  concurrencyPolicy: Forbid
  failedJobsHistoryLimit: 5
  startingDeadlineSeconds: 600
  successfulJobsHistoryLimit: 5
  jobTemplate:
    spec:
      template:
        spec:
          serviceAccountName: person-record-service
          containers:
            - name: housekeeping
              image: ghcr.io/ministryofjustice/hmpps-devops-tools
              args:
                - /bin/sh
                - -c
                - curl -XPUT --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 http://hmpps-person-record/queue-admin/retry-all-dlqs
          restartPolicy: Never```