### PR TITLE
CPR-174 delay restart from scheduled downtime to 630 to allow for RDS

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.9.4
+version: 2.9.5

--- a/charts/generic-service/README.md
+++ b/charts/generic-service/README.md
@@ -235,7 +235,8 @@ scheduledDowntime:
   enabled: true
 ```
 
-By default, this will shut down pods between 10pm-6am UTC on weekdays and all day on weekends.
+By default, this will shut down pods between 10pm - 6:45am UTC on weekdays and all day on weekends.
+6:45am was chosen as the RDS startup happens between 6am and 6:30am
 To change this schedule, update the `startup` and `shutdown` values:
 
 ```yaml

--- a/charts/generic-service/README.md
+++ b/charts/generic-service/README.md
@@ -235,8 +235,8 @@ scheduledDowntime:
   enabled: true
 ```
 
-By default, this will shut down pods between 10pm - 6:45am UTC on weekdays and all day on weekends.
-6:45am was chosen as the RDS startup happens between 6am and 6:30am
+By default, this will shut down pods between 10pm - 6:30am UTC on weekdays and all day on weekends.
+6:30am was chosen as the RDS startup happens between 6am and 6:30am
 To change this schedule, update the `startup` and `shutdown` values:
 
 ```yaml

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -216,8 +216,8 @@ postgresDatabaseRestore:
 
 scheduledDowntime:
   enabled: false
-  # Start at 6:45am UTC Monday-Friday
-  startup: '45 6 * * 1-5'
+  # Start at 6:30am UTC Monday-Friday
+  startup: '30 6 * * 1-5'
   # Stop at 10pm UTC Monday-Friday
   shutdown: '0 22 * * 1-5'
   serviceAccountName: scheduled-downtime-serviceaccount

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -216,8 +216,8 @@ postgresDatabaseRestore:
 
 scheduledDowntime:
   enabled: false
-  # Start at 6am UTC Monday-Friday
-  startup: '0 6 * * 1-5'
+  # Start at 6:45am UTC Monday-Friday
+  startup: '0 6 45 * 1-5'
   # Stop at 10pm UTC Monday-Friday
   shutdown: '0 22 * * 1-5'
   serviceAccountName: scheduled-downtime-serviceaccount

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -217,7 +217,7 @@ postgresDatabaseRestore:
 scheduledDowntime:
   enabled: false
   # Start at 6:45am UTC Monday-Friday
-  startup: '0 6 45 * 1-5'
+  startup: '45 6 * * 1-5'
   # Stop at 10pm UTC Monday-Friday
   shutdown: '0 22 * * 1-5'
   serviceAccountName: scheduled-downtime-serviceaccount


### PR DESCRIPTION
We are seeing lots of pod restarts around 6am down to database connection failures. It seems that the database startups happen around 615am, so any pods which depend on a database connection will be bound to fail.

<img width="791" alt="Screenshot 2024-02-23 at 12 34 01" src="https://github.com/ministryofjustice/hmpps-helm-charts/assets/76954782/aa291869-369c-44d3-84df-d255d57c5636">

