### PR TITLE
Add default securityContext values to align with cluster enforced values (via gatekeeper mutations).

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.9.7
+version: 2.9.8

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -32,6 +32,10 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
+# Changing the defaults values for securityContext below will have no effect. They are
+# listed here to prevent warning messages appearing and to also document the values.
+# If these values are not set here, then the gatekeeper admission controller will set.
+# See https://github.com/ministryofjustice/cloud-platform-terraform-gatekeeper/tree/main/resources/mutations
 securityContext:
   capabilities:
     drop:

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -32,13 +32,14 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  seccompProfile:
+    type: RuntimeDefault
 
 service:
   enabled: true


### PR DESCRIPTION
This change eliminates the kubectl warnings regarding missing securityContext settings.