### PR TITLE
Add default securityContext to all containers.

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -8,4 +8,4 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 3.0.1
+version: 3.0.2

--- a/charts/generic-service/ci/test-values.yaml
+++ b/charts/generic-service/ci/test-values.yaml
@@ -20,7 +20,7 @@ allowlist_groups:
     item-2: "6.0.0.0/32"
 
 scheduledDowntime:
- enabled: true
+  enabled: true
 
 retryDlqCronjob:
   enabled: true

--- a/charts/generic-service/ci/test-values.yaml
+++ b/charts/generic-service/ci/test-values.yaml
@@ -18,3 +18,12 @@ allowlist_groups:
   example-group-2:
     item-1: "5.0.0.0/32"
     item-2: "6.0.0.0/32"
+
+scheduledDowntime:
+ enabled: true
+
+retryDlqCronjob:
+  enabled: true
+
+postgresDatabaseRestore:
+  enabled: true

--- a/charts/generic-service/templates/prison-postgres-database-restore.yaml
+++ b/charts/generic-service/templates/prison-postgres-database-restore.yaml
@@ -49,6 +49,8 @@ spec:
                   mountPath: /bin/entrypoint.sh
                   readOnly: true
                   subPath: entrypoint.sh
+              securityContext:
+                {{- toYaml .Values.securityContext | nindent 14 }}
     {{- include "postgresRestore.envs" .Values | nindent 14 }}
           restartPolicy: "Never"
           volumes:

--- a/charts/generic-service/templates/prison-postgres-database-restore.yaml
+++ b/charts/generic-service/templates/prison-postgres-database-restore.yaml
@@ -41,7 +41,7 @@ spec:
         spec:
           containers:
             - name: postgres-restore
-              image: "ghcr.io/ministryofjustice/hmpps-devops-tools:latest"
+              image: "{{ .Values.postgresDatabaseRestore.image }}:{{ .Values.postgresDatabaseRestore.tag }}"
               command:
                 - /bin/entrypoint.sh
               volumeMounts:
@@ -50,7 +50,7 @@ spec:
                   readOnly: true
                   subPath: entrypoint.sh
               securityContext:
-                {{- toYaml .Values.securityContext | nindent 16 }}
+                {{- toYaml .Values.postgresDatabaseRestore.securityContext | nindent 16 }}
     {{- include "postgresRestore.envs" .Values | nindent 14 }}
           restartPolicy: "Never"
           volumes:

--- a/charts/generic-service/templates/prison-postgres-database-restore.yaml
+++ b/charts/generic-service/templates/prison-postgres-database-restore.yaml
@@ -50,7 +50,7 @@ spec:
                   readOnly: true
                   subPath: entrypoint.sh
               securityContext:
-                {{- toYaml .Values.securityContext | nindent 14 }}
+                {{- toYaml .Values.securityContext | nindent 16 }}
     {{- include "postgresRestore.envs" .Values | nindent 14 }}
           restartPolicy: "Never"
           volumes:

--- a/charts/generic-service/templates/retry-dlq-cronjob.yaml
+++ b/charts/generic-service/templates/retry-dlq-cronjob.yaml
@@ -27,6 +27,6 @@ spec:
                 - -c
                 - curl -XPUT --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 http://{{ include "generic-service.fullname" . }}/queue-admin/retry-all-dlqs
               securityContext:
-                {{- toYaml .Values.securityContext | nindent 14 }}
+                {{- toYaml .Values.securityContext | nindent 16 }}
           restartPolicy: Never
   {{- end}}

--- a/charts/generic-service/templates/retry-dlq-cronjob.yaml
+++ b/charts/generic-service/templates/retry-dlq-cronjob.yaml
@@ -26,5 +26,7 @@ spec:
                 - /bin/sh
                 - -c
                 - curl -XPUT --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 http://{{ include "generic-service.fullname" . }}/queue-admin/retry-all-dlqs
+              securityContext:
+                {{- toYaml .Values.securityContext | nindent 14 }}
           restartPolicy: Never
   {{- end}}

--- a/charts/generic-service/templates/retry-dlq-cronjob.yaml
+++ b/charts/generic-service/templates/retry-dlq-cronjob.yaml
@@ -27,6 +27,6 @@ spec:
                 - -c
                 - curl -XPUT --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 http://{{ include "generic-service.fullname" . }}/queue-admin/retry-all-dlqs
               securityContext:
-                {{- toYaml .Values.securityContext | nindent 16 }}
+                {{- toYaml .Values.retryDlqCronjob.securityContext | nindent 16 }}
           restartPolicy: Never
   {{- end}}

--- a/charts/generic-service/templates/scheduled-downtime-cronjob.yaml
+++ b/charts/generic-service/templates/scheduled-downtime-cronjob.yaml
@@ -17,7 +17,7 @@ spec:
         spec:
           containers:
             - name: hmpps-devops-tools
-              image: ghcr.io/ministryofjustice/hmpps-devops-tools:latest
+              image: "{{ .Values.scheduledDowntime.image }}:{{ .Values.scheduledDowntime.tag }}"
               args:
                 - kubectl
                 - scale
@@ -25,7 +25,7 @@ spec:
                 - {{ include "generic-service.fullname" . }}
                 - --replicas=0
               securityContext:
-                {{- toYaml .Values.securityContext | nindent 16 }}
+                {{- toYaml .Values.scheduledDowntime.securityContext | nindent 16 }}
           restartPolicy: OnFailure
           serviceAccountName: {{ .Values.scheduledDowntime.serviceAccountName }}
 ---

--- a/charts/generic-service/templates/scheduled-downtime-cronjob.yaml
+++ b/charts/generic-service/templates/scheduled-downtime-cronjob.yaml
@@ -24,6 +24,8 @@ spec:
                 - deploy
                 - {{ include "generic-service.fullname" . }}
                 - --replicas=0
+              securityContext:
+                {{- toYaml .Values.securityContext | nindent 14 }}
           restartPolicy: OnFailure
           serviceAccountName: {{ .Values.scheduledDowntime.serviceAccountName }}
 ---
@@ -53,6 +55,8 @@ spec:
                 - {{ include "generic-service.fullname" . }}
                 - --current-replicas=0
                 - --replicas={{ .Values.replicaCount }}
+              securityContext:
+                {{- toYaml .Values.securityContext | nindent 14 }}
           restartPolicy: OnFailure
           serviceAccountName: {{ .Values.scheduledDowntime.serviceAccountName }}
 {{- end }}

--- a/charts/generic-service/templates/scheduled-downtime-cronjob.yaml
+++ b/charts/generic-service/templates/scheduled-downtime-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
                 - {{ include "generic-service.fullname" . }}
                 - --replicas=0
               securityContext:
-                {{- toYaml .Values.securityContext | nindent 14 }}
+                {{- toYaml .Values.securityContext | nindent 16 }}
           restartPolicy: OnFailure
           serviceAccountName: {{ .Values.scheduledDowntime.serviceAccountName }}
 ---
@@ -56,7 +56,7 @@ spec:
                 - --current-replicas=0
                 - --replicas={{ .Values.replicaCount }}
               securityContext:
-                {{- toYaml .Values.securityContext | nindent 14 }}
+                {{- toYaml .Values.securityContext | nindent 16 }}
           restartPolicy: OnFailure
           serviceAccountName: {{ .Values.scheduledDowntime.serviceAccountName }}
 {{- end }}

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -36,7 +36,7 @@ podSecurityContext: {}
 # listed here to prevent warning messages appearing and to also document the values.
 # If these values are not set here, then the gatekeeper admission controller will set.
 # See https://github.com/ministryofjustice/cloud-platform-terraform-gatekeeper/tree/main/resources/mutations
-securityContext:
+securityContext: &securityContext
   capabilities:
     drop:
     - ALL
@@ -203,6 +203,11 @@ custommetrics:
   metricsPath: /metrics
   metricsPort: http
 
+# Devops tools image is used in cronjob below - should be kept up-to-date.
+# using 'latest' tag causes warning messages, so using 'main' tag instead.
+devopsToolsImage: &devopsToolsImage ghcr.io/ministryofjustice/hmpps-devops-tools
+devopsToolsTag: &devopsToolsTag main
+
 postgresDatabaseRestore:
   enabled: false
 # Required environment secrets for the restore script:
@@ -217,6 +222,9 @@ postgresDatabaseRestore:
 #      DB_USER_PREPROD: "database_username"
 #      DB_PASS_PREPROD: "database_password"
 #      DB_HOST_PREPROD: "rds_instance_address"
+  image: *devopsToolsImage
+  tag: *devopsToolsTag
+  securityContext: *securityContext
 
 scheduledDowntime:
   enabled: false
@@ -227,10 +235,15 @@ scheduledDowntime:
   serviceAccountName: scheduled-downtime-serviceaccount
   # every 10 minutes between 7am and 10pm UTC Monday-Friday
   retryDlqSchedule: "*/10 7-21 * * 1-5"
+  image: *devopsToolsImage
+  tag: *devopsToolsTag
+  securityContext: *securityContext
 
 retryDlqCronjob:
   enabled: false
   # every 10 minutes
   retryDlqSchedule: "*/10 * * * *"
-  image: ghcr.io/ministryofjustice/hmpps-devops-tools
-  tag: latest
+  image: *devopsToolsImage
+  tag: *devopsToolsTag
+  securityContext: *securityContext
+

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -246,4 +246,3 @@ retryDlqCronjob:
   image: *devopsToolsImage
   tag: *devopsToolsTag
   securityContext: *securityContext
-


### PR DESCRIPTION
securityContext is now set for all containers that are part of cronjobs.

Added fix for warning messages about using `latest` image tag.