### PR TITLE
CPR-307 do not fail startup cronjob if the number of replicas is not 0

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -8,4 +8,4 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 3.3.0
+version: 3.3.1

--- a/charts/generic-service/templates/scheduled-downtime-cronjob.yaml
+++ b/charts/generic-service/templates/scheduled-downtime-cronjob.yaml
@@ -53,7 +53,6 @@ spec:
                 - scale
                 - deploy
                 - {{ include "generic-service.fullname" . }}
-                - --current-replicas=0
                 - --replicas={{ .Values.replicaCount }}
               securityContext:
                 {{- toYaml .Values.securityContext | nindent 16 }}


### PR DESCRIPTION
```mark.rees@MJ004359 hmpps-person-record % kubectl get jobs -n hmpps-person-record-dev                                                
NAME                                   COMPLETIONS   DURATION   AGE
hmpps-person-record-startup-28637670   0/1           2m33s      2m42s
mark.rees@MJ004359 hmpps-person-record % kubectl logs job.batch/hmpps-person-record-startup-28637670 -n hmpps-person-record-dev
error: Expected replicas to be 0, was 1
```

This is a problem in British Summer Time if you start work a bit early and merge a pull request.

This job has now failed and will alert, although the number of replicas is as desired. I don't think we need to check the number of replicas on startup. We don't do so on shutdown