### PR TITLE
Update README to describe how to mount volumed k8s secrets

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -8,4 +8,4 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 3.6.1
+version: 3.6.2

--- a/charts/generic-service/README.md
+++ b/charts/generic-service/README.md
@@ -102,17 +102,11 @@ generic-service:
       AP_ARN: "arn?" # optional
 
   # Pre-existing kubernetes secrets to load as mounted file(s) within pod/container
-  # namespace_secrets_to_file:
-  #   [name of kubernetes secret]:
-  #     [path of directory used by volume mount]:
-  #       - [key of kubernetes secret - also name of the mounted file]
-  # E.g.
-  namespace_secrets_to_file:
-    secret-name:
-      /app/secrets:
-        - config.yaml
-        - key.pem
 ```
+
+### Mounting Secrets
+
+[K8s documentation to mount secrets](https://kubernetes.io/docs/concepts/configuration/secret/#use-case-dotfiles-in-a-secret-volume)
 
 When loading secrets as mounted volumes inside a container the pre-existing kubernetes secret should look like the following, as per example above:
 
@@ -123,13 +117,6 @@ apiVersion: v1
 data:
   config.yaml: [base64 encoded file contents]
   key.pem: [base64 encoded file contents]
-```
-
-The result of the above secret, along with the example `namespace_secrets_to_file` value would mean running containers be able read/load file contents from:
-
-```sh
-/app/secrets/config.yaml
-/app/secrets/key.pem
 ```
 
 ### Injecting env into batch yamls

--- a/charts/generic-service/README.md
+++ b/charts/generic-service/README.md
@@ -108,6 +108,22 @@ generic-service:
 
 [K8s documentation to mount secrets](https://kubernetes.io/docs/concepts/configuration/secret/#use-case-dotfiles-in-a-secret-volume)
 
+```yaml
+  volumes:
+    - name: secrets
+      secret:
+        secretName: "k8s-secret-name"
+        items:
+          - key: secret-key
+            path: secret-file-name
+  volumeMounts:
+    - name: secrets
+      mountPath: /app/secrets
+      readOnly: true
+```
+
+This configuration will create a file `/app/secrets/secret-file-name` with the content of the k8s secret within it.
+
 When loading secrets as mounted volumes inside a container the pre-existing kubernetes secret should look like the following, as per example above:
 
 ```yaml
@@ -115,8 +131,7 @@ kind: Secret
 type: Opaque
 apiVersion: v1
 data:
-  config.yaml: [base64 encoded file contents]
-  key.pem: [base64 encoded file contents]
+  secret-key: [base64 encoded file contents]
 ```
 
 ### Injecting env into batch yamls


### PR DESCRIPTION
Link to documentation https://kubernetes.io/docs/concepts/configuration/secret/#use-case-dotfiles-in-a-secret-volume

in the README.md to describe how to mount k8s secrets.


Update the Helm Chart version to `3.6.2` to pass automated tests