### PR TITLE
Add resources definition to the data extractor template

### DIFF
--- a/charts/generic-data-analytics-extractor/Chart.yaml
+++ b/charts/generic-data-analytics-extractor/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: generic-data-analytics-extractor
 description: Runs a daily cron job which extracts and sends a database dump to the analytical platform
-version: 1.1.1
+version: 1.1.2

--- a/charts/generic-data-analytics-extractor/Chart.yaml
+++ b/charts/generic-data-analytics-extractor/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: generic-data-analytics-extractor
 description: Runs a daily cron job which extracts and sends a database dump to the analytical platform
-version: 1.1.2
+version: 1.2.0

--- a/charts/generic-data-analytics-extractor/templates/cronjob.yaml
+++ b/charts/generic-data-analytics-extractor/templates/cronjob.yaml
@@ -64,6 +64,8 @@ spec:
                   value: "{{ .Values.saveEventsLog }}"
                 - name: DATA_PRODUCT_NAME
                   value: "{{ .Values.dataProductName }}"
+              resources:
+                {{- toYaml .Values.resources | nindent 16 }}
 {{- if .Values.dataPlatformApiAuthSecretName }}
                 - name: API_AUTH
                   valueFrom:

--- a/charts/generic-data-analytics-extractor/values.yaml
+++ b/charts/generic-data-analytics-extractor/values.yaml
@@ -41,3 +41,6 @@ fullnameOverride: ""
 image:
   repository: ministryofjustice/data-engineering-data-extractor
   tag: v1.2.2
+
+# Optional definition of resources useful for services with more data to extract
+resources: {}


### PR DESCRIPTION
* Allows container resources to be defined as part of the template. Useful for larger data extraction use cases.