### PR TITLE
Make restore transactional to prevent leaving db in an inconsistent state

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -8,4 +8,4 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 3.10.2
+version: 3.10.3

--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -8,4 +8,4 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 3.10.1
+version: 3.10.2

--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -8,4 +8,4 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 3.10.0
+version: 3.10.1

--- a/charts/generic-service/prison-postgres-restore.sh
+++ b/charts/generic-service/prison-postgres-restore.sh
@@ -85,7 +85,7 @@ fi
 pg_dump -h "$DB_HOST" -U "$DB_USER" ${SCHEMA_TO_RESTORE:+-n $SCHEMA_TO_RESTORE} -Fc --no-privileges -v --file=/tmp/db.dump "$DB_NAME"
 
 # Restore database to preprod
-pg_restore -h "$DB_HOST_PREPROD" -U "$DB_USER_PREPROD" ${SCHEMA_TO_RESTORE:+-n $SCHEMA_TO_RESTORE} --clean --no-owner -v -d "$DB_NAME_PREPROD" /tmp/db.dump
+pg_restore -h "$DB_HOST_PREPROD" -U "$DB_USER_PREPROD" ${SCHEMA_TO_RESTORE:+-n $SCHEMA_TO_RESTORE} --clean --if-exists --no-owner --single-transaction -v -d "$DB_NAME_PREPROD" /tmp/db.dump
 
 # now stash away the restore status in postgres
 echo -e "\nWriting restore date of $DATABASE_RESTORE_DATE to the preprod database"

--- a/charts/generic-service/prison-postgres-restore.sh
+++ b/charts/generic-service/prison-postgres-restore.sh
@@ -7,6 +7,23 @@ check_http() { http --stream --check-status --ignore-stdin --timeout=600 "$@"; }
 psql_preprod() { psql -h "$DB_HOST_PREPROD" -U "$DB_USER_PREPROD" -d "$DB_NAME_PREPROD" -At -c "$@"; }
 psql_prod() { psql -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" -At -c "$@"; }
 
+# grab last restore date from Prison API
+if ! DATABASE_RESTORE_INFO=$(check_http GET "$PRISON_API_BASE_URL/api/restore-info"); then
+  echo -e "\nUnable to find any restore information."
+  if [[ -z "${FORCE_RUN+x}" ]]; then
+    echo -e "\nTo force a run set the FORCE_RUN environment variable when creating the job (see README.md in hmpps-helm-charts/generic-service)"
+    echo "$DATABASE_RESTORE_INFO"
+    exit 0
+  fi
+  echo -e "\nRun forced"
+  DATABASE_RESTORE_DATE=$(date +%F) # default to current date
+else
+  DATABASE_RESTORE_DATE=$(echo "$DATABASE_RESTORE_INFO" | jq -r .)
+fi
+
+echo "${DB_HOST}:5432:${DB_NAME}:${DB_USER}:${DB_PASS}" > ~/.pgpass
+echo "${DB_HOST_PREPROD}:5432:${DB_NAME_PREPROD}:${DB_USER_PREPROD}:${DB_PASS_PREPROD}" >> ~/.pgpass
+chmod 0600 ~/.pgpass
 
 # Check postgres server versions and adjust PATH to use the correct version of pg client tools.
 PSQL_PREPROD_VERSION=$(psql_preprod "SHOW server_version;" | cut -d"." -f1)
@@ -28,24 +45,6 @@ else
   echo "Path $PSQL_PATH does not exist"
   exit 1
 fi
-
-# grab last restore date from Prison API
-if ! DATABASE_RESTORE_INFO=$(check_http GET "$PRISON_API_BASE_URL/api/restore-info"); then
-  echo -e "\nUnable to find any restore information."
-  if [[ -z "${FORCE_RUN+x}" ]]; then
-    echo -e "\nTo force a run set the FORCE_RUN environment variable when creating the job (see README.md in hmpps-helm-charts/generic-service)"
-    echo "$DATABASE_RESTORE_INFO"
-    exit 0
-  fi
-  echo -e "\nRun forced"
-  DATABASE_RESTORE_DATE=$(date +%F) # default to current date
-else
-  DATABASE_RESTORE_DATE=$(echo "$DATABASE_RESTORE_INFO" | jq -r .)
-fi
-
-echo "${DB_HOST}:5432:${DB_NAME}:${DB_USER}:${DB_PASS}" > ~/.pgpass
-echo "${DB_HOST_PREPROD}:5432:${DB_NAME_PREPROD}:${DB_USER_PREPROD}:${DB_PASS_PREPROD}" >> ~/.pgpass
-chmod 0600 ~/.pgpass
 
 # Check that we can connect to preprod postgres and create restore table
 if ! OUTPUT=$(psql_preprod "create table if not exists ${SCHEMA_TO_RESTORE:+${SCHEMA_TO_RESTORE}.}restore_status(restore_date date)"); then


### PR DESCRIPTION
Currently if the pod is destroyed or removed for any reason including failures and timeouts, the database can be left incomplete with missing constraints and indices. Adding a parameter to ensure the entire thing is ran in a single transaction.