### PR TITLE
Support active record in postgres restore script

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -8,4 +8,4 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 3.10.3
+version: 3.10.4

--- a/charts/generic-service/README.md
+++ b/charts/generic-service/README.md
@@ -174,6 +174,10 @@ should be injected into the production namespace, see https://github.com/ministr
 for an example PR. Both production and pre-production credentials should then be added as a `namespace_secrets:` section,
 see the `values.yaml` in this repository for an example of the secrets and other options.
 
+Currently, Flyway and ActiveRecord database migrations are supported. The default is Flyway. You can change this by
+supplying the `MIGRATIONS_VENDOR` environment variable in the `env:` section (see `values.yaml` for an example). Possible 
+values are `flyway` and `active_record`.
+
 If you have set up a schema separate to the default 'public' schema and want to refresh that schema, you must additionally
 supply the `SCHEMA_TO_RESTORE` environment variable in the `env:` section (again see the `values.yaml` for an example).
 If you have additionally set up a separate (non-admin) user to access this schema you may find that after refresh the permissions

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -234,9 +234,10 @@ postgresDatabaseRestore:
 #      DB_USER_PREPROD: "database_username"
 #      DB_PASS_PREPROD: "database_password"
 #      DB_HOST_PREPROD: "rds_instance_address"
-# Optional schema name if not using the default 'public' schema:
+# Optional schema name and migrations vendor if not using the default 'public' schema or 'flyway' vendor:
 #  env:
 #    SCHEMA_TO_RESTORE: "my_schema"
+#    MIGRATIONS_VENDOR: "active_record"
   image: *postgresToolsImage
   tag: *postgresToolsTag
   securityContext: *securityContext


### PR DESCRIPTION
We maintain a mixed set of HMPPS applications, some of them are legacy and still using Rails. We are already using the db restore job with kotlin/flyway apps but would be great to also be able to use it in our Rails apps, where we use this helm chart successfully.

This PR allows supplying an optional `MIGRATIONS_VENDOR` env variable to `postgresDatabaseRestore`. If not provided, current behaviour (flyway) remains intact, thus the minor patch version.

Will be very easy to expand this to other migration types, if necessary in the future.