### PR TITLE
PI-2965 Add support for timeZone in scheduled downtime job

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -8,4 +8,4 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 3.10.4
+version: 3.11.0

--- a/charts/generic-service/README.md
+++ b/charts/generic-service/README.md
@@ -269,6 +269,7 @@ scheduledDowntime:
   enabled: true
   startup: '0 6 * * 1-5' # Start at 6am UTC Monday-Friday
   shutdown: '0 22 * * 1-5' # Stop at 10pm UTC Monday-Friday
+  timeZone: Etc/UTC
   serviceAccountName: scheduled-downtime-serviceaccount # This must match the service account name in the Terraform module
 ```
 

--- a/charts/generic-service/templates/scheduled-downtime-cronjob.yaml
+++ b/charts/generic-service/templates/scheduled-downtime-cronjob.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "generic-service.labels" . | nindent 4 }}
 spec:
   schedule: {{ .Values.scheduledDowntime.shutdown }}
+  timeZone: {{ .Values.scheduledDowntime.timeZone }}
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 5
@@ -37,6 +38,7 @@ metadata:
     {{- include "generic-service.labels" . | nindent 4 }}
 spec:
   schedule: {{ .Values.scheduledDowntime.startup }}
+  timeZone: {{ .Values.scheduledDowntime.timeZone }}
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 5

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -250,6 +250,7 @@ scheduledDowntime:
   startup: '30 6 * * 1-5'
   # Stop at 10pm UTC Monday-Friday
   shutdown: '0 22 * * 1-5'
+  timeZone: Etc/UTC
   serviceAccountName: scheduled-downtime-serviceaccount
   # every 10 minutes between 7am and 10pm UTC Monday-Friday
   retryDlqSchedule: "*/10 7-21 * * 1-5"


### PR DESCRIPTION
Non-production RDS databases on Cloud Platform are stopped between 10pm-6am UTC, so for most services the time zone should be left as "Etc/UTC". However, for other services that have dependencies with a downtime schedule in a different timezone (e.g. "Europe/London"), then this allows them to ensure the schedules match.

Specifically, this allows probation integration services that connect to the Delius database to ensure the pods are offline while the database is offline (9PM-6AM Europe/London time).