### PR TITLE
Update ingress and application rules regex.  Fix all summary, message, dashboard annotations - make them all consistent.

### DIFF
--- a/charts/generic-prometheus-alerts/Chart.yaml
+++ b/charts/generic-prometheus-alerts/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.11.6
+version: 1.11.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/generic-prometheus-alerts/ci/tests/application-alerts-tests.yaml
+++ b/charts/generic-prometheus-alerts/ci/tests/application-alerts-tests.yaml
@@ -69,7 +69,7 @@ tests:
             exp_annotations:
               message: CronJob test-application-dev/test-application-cronjob is failing.
               runbook_url: https://runbook.com/application-cronjob-failed
-              dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/application-alerts/application-alerts?orgId=1&var-namespace=test-application-dev
+              dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/golden-signals/golden-signals?orgId=1&var-namespace=test-application-dev&var-service=test-application"
               summary: CronJob is failing.
 
   # example two - three jobs (from the same cronjob) have run, the first two failed, the last one succeeded
@@ -176,6 +176,5 @@ tests:
             exp_annotations:
               message: CronJob test-application-dev/test-application-cronjob is failing.
               runbook_url: https://runbook.com/application-cronjob-failed
-              dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/application-alerts/application-alerts?orgId=1&var-namespace=test-application-dev
+              dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/golden-signals/golden-signals?orgId=1&var-namespace=test-application-dev&var-service=test-application"
               summary: CronJob is failing.
-

--- a/charts/generic-prometheus-alerts/ci/tests/ingress-alerts-tests-hourly.yaml
+++ b/charts/generic-prometheus-alerts/ci/tests/ingress-alerts-tests-hourly.yaml
@@ -46,4 +46,5 @@ tests:
             exp_annotations:
               message: "Ingress test-application-dev/test-application-v1-2 is not serving enough 2xx responses."
               runbook_url: "https://runbook.com/ingress-2xx-responses"
-              dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/f1e13059dfd23fdcaf479f4fa833f92610c2dfa5/kubernetes-ingress-traffic?1&var-namespace=test-application-dev&var-ingress=test-application(-v1-2)&from=now-2h&to=now"
+              dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/golden-signals/golden-signals?orgId=1&var-namespace=test-application-dev&var-service=test-application"
+              summary: "Ingress not serving enough 2xx responses."

--- a/charts/generic-prometheus-alerts/ci/tests/ingress-alerts-tests-hourly.yaml
+++ b/charts/generic-prometheus-alerts/ci/tests/ingress-alerts-tests-hourly.yaml
@@ -7,25 +7,25 @@ evaluation_interval: 1h
 tests:
   - interval: 1h
     input_series:
-      - series: 'nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-ingress", path="/", status="200"}'
+      - series: 'nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-v1-2", path="/", status="200"}'
         values: '0 1 3 2+4x10 5 6'
-      - series: 'nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-ingress", path="/", status="201"}'
+      - series: 'nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-v1-2", path="/", status="201"}'
         values: '0 2 5 2+4x10 5 6'
 
     name: 2xxResponses alert fired as not enough requests in given time window
 
     promql_expr_test:
-      - expr: sum by (ingress, exported_namespace) (increase(nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-ingress", path="/", status=~"2.*"}[1h])) < 10
+      - expr: sum by (ingress, exported_namespace) (increase(nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-v1-2", path="/", status=~"2.*"}[1h])) < 10
         eval_time: 2h
         exp_samples:
-          - labels: '{exported_namespace="test-application-dev", ingress="test-application-ingress"}'
+          - labels: '{exported_namespace="test-application-dev", ingress="test-application-v1-2"}'
             value: 5 # this is (5-2)+(3-1)
-      - expr: sum by (ingress, exported_namespace) (increase(nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-ingress", path="/", status=~"2.*"}[1h])) < 10
+      - expr: sum by (ingress, exported_namespace) (increase(nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-v1-2", path="/", status=~"2.*"}[1h])) < 10
         eval_time: 8h
         exp_samples:
-          - labels: '{exported_namespace="test-application-dev", ingress="test-application-ingress"}'
+          - labels: '{exported_namespace="test-application-dev", ingress="test-application-v1-2"}'
             value: 8 # since incrementing every hour by 4 for each ingress
-      - expr: sum by (ingress, exported_namespace) (increase(nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-ingress", path="/", status=~"2.*"}[1h])) < 10
+      - expr: sum by (ingress, exported_namespace) (increase(nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-v1-2", path="/", status=~"2.*"}[1h])) < 10
         eval_time: 14h
         exp_samples: [] # no samples since we have 5+5 requests at this time
 
@@ -37,13 +37,13 @@ tests:
           - exp_labels:
               alertname: 2xxResponses
               exported_namespace: test-application-dev
-              ingress: test-application-ingress
+              ingress: test-application-v1-2
               severity: alert-severity-tag
               application: test-application
               businessUnit: hmpps
               environment: none
               productId: none
             exp_annotations:
-              message: "Ingress test-application-dev/test-application-ingress is not serving enough 2xx responses."
+              message: "Ingress test-application-dev/test-application-v1-2 is not serving enough 2xx responses."
               runbook_url: "https://runbook.com/ingress-2xx-responses"
-              dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/f1e13059dfd23fdcaf479f4fa833f92610c2dfa5/kubernetes-ingress-traffic?1&var-namespace=test-application-dev&var-ingress=test-application.*&from=now-2h&to=now"
+              dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/f1e13059dfd23fdcaf479f4fa833f92610c2dfa5/kubernetes-ingress-traffic?1&var-namespace=test-application-dev&var-ingress=test-application(-v1-2)&from=now-2h&to=now"

--- a/charts/generic-prometheus-alerts/ci/tests/ingress-alerts-tests.yaml
+++ b/charts/generic-prometheus-alerts/ci/tests/ingress-alerts-tests.yaml
@@ -42,9 +42,10 @@ tests:
               environment: none
               productId: none
             exp_annotations:
+              summary: "Ingress serving 5xx responses."
               message: "Ingress test-application-dev/test-application-v1-2 is serving 5xx responses."
               runbook_url: https://runbook.com/ingress-5xx-error-responses
-              dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/f1e13059dfd23fdcaf479f4fa833f92610c2dfa5/kubernetes-ingress-traffic?1&var-namespace=test-application-dev&var-ingress=test-application(-v1-2)&from=now-5m&to=now
+              dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/golden-signals/golden-signals?orgId=1&var-namespace=test-application-dev&var-service=test-application"
       # and that the 5xx health alert is not firing
       - eval_time: 6m
         alertname: 5xxErrorResponsesOnHealthEndpoint
@@ -88,9 +89,10 @@ tests:
               environment: none
               productId: none
             exp_annotations:
+              summary: "High rate of 5xx errors on /health."
               message: "High rate of 5xx errors detected on /health path in Ingress test-application-dev/test-application-v1-2."
               runbook_url: https://runbook.com/ingress-5xx-error-responses
-              dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/f1e13059dfd23fdcaf479f4fa833f92610c2dfa5/kubernetes-ingress-traffic?1&var-namespace=test-application-dev&var-ingress=test-application(-v1-2)&from=now-5m&to=now
+              dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/golden-signals/golden-signals?orgId=1&var-namespace=test-application-dev&var-service=test-application"
 
   - interval: 1m
     input_series:
@@ -171,9 +173,10 @@ tests:
               environment: none
               productId: none
             exp_annotations:
+              summary: "Ingress is being rate limited."
               message: "Rate limit is being applied on ingress test-application-dev/test-application-v1-2."
               runbook_url: https://runbook.com/ingress-rate-limiting
-              dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/golden-signals/golden-signals?orgId=1&var-namespace=test-application-dev&var-service=test-application
+              dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/golden-signals/golden-signals?orgId=1&var-namespace=test-application-dev&var-service=test-application"
 
   - interval: 1m
     input_series:
@@ -232,9 +235,10 @@ tests:
               environment: none
               productId: none
             exp_annotations:
+              summary: "Mod_Security blocking ingress."
               message: "Mod_Security is blocking ingress test-application-dev/test-application-v1-2. Blocking http requests at rate of 0.37 per second."
               runbook_url: https://runbook.com/ingress-modsecurity-blocking
-              dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/golden-signals/golden-signals?orgId=1&var-namespace=test-application-dev&var-service=test-application
+              dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/golden-signals/golden-signals?orgId=1&var-namespace=test-application-dev&var-service=test-application"
 
   - interval: 1m
     input_series:

--- a/charts/generic-prometheus-alerts/ci/tests/ingress-alerts-tests.yaml
+++ b/charts/generic-prometheus-alerts/ci/tests/ingress-alerts-tests.yaml
@@ -8,9 +8,9 @@ evaluation_interval: 1m
 tests:
   - interval: 1m
     input_series:
-      - series: 'nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-ingress", path="/", status="500"}'
+      - series: 'nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-v1-2", path="/", status="500"}'
         values: '0 1 3'
-      - series: 'nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-ingress", path="/", status="501"}'
+      - series: 'nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-v1-2", path="/", status="501"}'
         values: '0 2 5'
 
     name: 5xxErrorResponses alert fired as request rate increases over the duration of the 1 minute time range window
@@ -21,10 +21,10 @@ tests:
     #   which is greater than 0
     #   the average of those is 0.041
     promql_expr_test:
-      - expr: avg(rate(nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-ingress", path="/", status=~"5.*"}[1m]) > 0) by (ingress, exported_namespace)
+      - expr: avg(rate(nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-v1-2", path="/", status=~"5.*"}[1m]) > 0) by (ingress, exported_namespace)
         eval_time: 2m
         exp_samples:
-          - labels: '{exported_namespace="test-application-dev", ingress="test-application-ingress"}'
+          - labels: '{exported_namespace="test-application-dev", ingress="test-application-v1-2"}'
             value: 0.04166666666666667
 
     alert_rule_test:
@@ -35,16 +35,16 @@ tests:
           - exp_labels:
               alertname: 5xxErrorResponses
               exported_namespace: test-application-dev
-              ingress: test-application-ingress
+              ingress: test-application-v1-2
               severity: alert-severity-tag
               application: test-application
               businessUnit: hmpps
               environment: none
               productId: none
             exp_annotations:
-              message: "Ingress test-application-dev/test-application-ingress is serving 5xx responses."
+              message: "Ingress test-application-dev/test-application-v1-2 is serving 5xx responses."
               runbook_url: https://runbook.com/ingress-5xx-error-responses
-              dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/f1e13059dfd23fdcaf479f4fa833f92610c2dfa5/kubernetes-ingress-traffic?1&var-namespace=test-application-dev&var-ingress=test-application.*&from=now-5m&to=now
+              dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/f1e13059dfd23fdcaf479f4fa833f92610c2dfa5/kubernetes-ingress-traffic?1&var-namespace=test-application-dev&var-ingress=test-application(-v1-2)&from=now-5m&to=now
       # and that the 5xx health alert is not firing
       - eval_time: 6m
         alertname: 5xxErrorResponsesOnHealthEndpoint
@@ -52,21 +52,21 @@ tests:
 
   - interval: 1m
     input_series:
-      - series: 'nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-ingress", path="/health", status="500"}'
+      - series: 'nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-v1-2", path="/health", status="500"}'
         values: '0 1 3'
-      - series: 'nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-ingress", path="/health", status="501"}'
+      - series: 'nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-v1-2", path="/health", status="501"}'
         values: '0 6 5'
 
     name: 5xxErrorResponses alert not fired as path is for /health
 
     promql_expr_test:
-      - expr: avg(rate(nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-ingress", path="/", status=~"5.*"}[5m]) > 0) by (ingress, exported_namespace)
+      - expr: avg(rate(nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-v1-2", path="/", status=~"5.*"}[5m]) > 0) by (ingress, exported_namespace)
         eval_time: 6m
         exp_samples:
-      - expr: avg(rate(nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-ingress", path="/health", status=~"5.*"}[5m]) > 0.004) by (ingress, exported_namespace)
+      - expr: avg(rate(nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-v1-2", path="/health", status=~"5.*"}[5m]) > 0.004) by (ingress, exported_namespace)
         eval_time: 6m
         exp_samples:
-          - labels: '{exported_namespace="test-application-dev", ingress="test-application-ingress"}'
+          - labels: '{exported_namespace="test-application-dev", ingress="test-application-v1-2"}'
             value: 0.0175
 
     alert_rule_test:
@@ -81,16 +81,16 @@ tests:
           - exp_labels:
               alertname: 5xxErrorResponsesOnHealthEndpoint
               exported_namespace: test-application-dev
-              ingress: test-application-ingress
+              ingress: test-application-v1-2
               severity: alert-severity-tag
               application: test-application
               businessUnit: hmpps
               environment: none
               productId: none
             exp_annotations:
-              message: "High rate of 5xx errors detected on /health path in Ingress test-application-dev/test-application-ingress."
+              message: "High rate of 5xx errors detected on /health path in Ingress test-application-dev/test-application-v1-2."
               runbook_url: https://runbook.com/ingress-5xx-error-responses
-              dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/f1e13059dfd23fdcaf479f4fa833f92610c2dfa5/kubernetes-ingress-traffic?1&var-namespace=test-application-dev&var-ingress=test-application.*&from=now-5m&to=now
+              dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/f1e13059dfd23fdcaf479f4fa833f92610c2dfa5/kubernetes-ingress-traffic?1&var-namespace=test-application-dev&var-ingress=test-application(-v1-2)&from=now-5m&to=now
 
   - interval: 1m
     input_series:
@@ -116,7 +116,7 @@ tests:
 
   - interval: 1m
     input_series:
-      - series: 'nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-ingress", path="/", status="500"}'
+      - series: 'nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-v1-2", path="/", status="500"}'
         values: '0 1 0'
 
     name: 5xxErrorResponses alert not fired as request rate decreases over the duration of the 1 minute time range window
@@ -124,7 +124,7 @@ tests:
     # this is here to help folks better understand the promql expression
     # at 2m the rate (increase per second) in the last minute: 0 which is not greater than 0, assert nothing is returned
     promql_expr_test:
-      - expr: avg(rate(nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-ingress", path="/", status=~"5.*"}[1m]) > 0) by (ingress, exported_namespace)
+      - expr: avg(rate(nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-v1-2", path="/", status=~"5.*"}[1m]) > 0) by (ingress, exported_namespace)
         eval_time: 2m
         exp_samples: []
 
@@ -139,7 +139,7 @@ tests:
   ##
   - interval: 1m
     input_series:
-      - series: 'nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-ingress", status="429"}'
+      - series: 'nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-v1-2", status="429"}'
         values: '0 1 3'
 
     name: RatelimitBlocking alert fired as request rate increases over the duration of the 1 minute time range window
@@ -150,10 +150,10 @@ tests:
     #   which is greater than 0
     #   the average is 0.03
     promql_expr_test:
-      - expr: avg(rate(nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-ingress", status=~"429"}[1m]) > 0) by (ingress, exported_namespace)
+      - expr: avg(rate(nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-v1-2", status=~"429"}[1m]) > 0) by (ingress, exported_namespace)
         eval_time: 2m
         exp_samples:
-          - labels: '{exported_namespace="test-application-dev", ingress="test-application-ingress"}'
+          - labels: '{exported_namespace="test-application-dev", ingress="test-application-v1-2"}'
             value: 0.03333333333333333
 
     alert_rule_test:
@@ -164,20 +164,20 @@ tests:
           - exp_labels:
               alertname: RatelimitBlocking
               exported_namespace: test-application-dev
-              ingress: test-application-ingress
+              ingress: test-application-v1-2
               severity: alert-severity-tag
               application: test-application
               businessUnit: hmpps
               environment: none
               productId: none
             exp_annotations:
-              message: "Rate limit is being applied on ingress test-application-dev/test-application-ingress."
+              message: "Rate limit is being applied on ingress test-application-dev/test-application-v1-2."
               runbook_url: https://runbook.com/ingress-rate-limiting
               dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/golden-signals/golden-signals?orgId=1&var-namespace=test-application-dev&var-service=test-application
 
   - interval: 1m
     input_series:
-      - series: 'nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-ingress", status="429"}'
+      - series: 'nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-v1-2", status="429"}'
         values: '0 1 0'
 
     name: RatelimitBlocking alert not fired as request rate decreases over the duration of the 1 minute time range window
@@ -185,7 +185,7 @@ tests:
     # this is here to help folks better understand the promql expression
     # at 2m the rate (increase per second) in the last minute: 0 which is not greater than 0, assert nothing is returned
     promql_expr_test:
-      - expr: avg(rate(nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-ingress", status=~"429"}[1m]) > 0) by (ingress, exported_namespace)
+      - expr: avg(rate(nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-v1-2", status=~"429"}[1m]) > 0) by (ingress, exported_namespace)
         eval_time: 2m
         exp_samples: []
 
@@ -200,7 +200,7 @@ tests:
   ##
   - interval: 1m
     input_series:
-      - series: 'nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-ingress", status="406"}'
+      - series: 'nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-v1-2", status="406"}'
         values: '0 21 43'
 
     name: ModSecurityBlocking alert fired as request rate is greater than 20 over the duration of the 1 minute time range window
@@ -211,10 +211,10 @@ tests:
     #   which is greater than 0.33
     #   the average is 0.36
     promql_expr_test:
-      - expr: avg(rate(nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-ingress", status=~"406"}[1m]) > 0.33) by (ingress, exported_namespace)
+      - expr: avg(rate(nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-v1-2", status=~"406"}[1m]) > 0.33) by (ingress, exported_namespace)
         eval_time: 2m
         exp_samples:
-          - labels: '{exported_namespace="test-application-dev", ingress="test-application-ingress"}'
+          - labels: '{exported_namespace="test-application-dev", ingress="test-application-v1-2"}'
             value: 0.36666666666666664
 
     alert_rule_test:
@@ -225,20 +225,20 @@ tests:
           - exp_labels:
               alertname: ModSecurityBlocking
               exported_namespace: test-application-dev
-              ingress: test-application-ingress
+              ingress: test-application-v1-2
               severity: alert-severity-tag
               application: test-application
               businessUnit: hmpps
               environment: none
               productId: none
             exp_annotations:
-              message: "Mod_Security is blocking ingress test-application-dev/test-application-ingress. Blocking http requests at rate of 0.37 per second."
+              message: "Mod_Security is blocking ingress test-application-dev/test-application-v1-2. Blocking http requests at rate of 0.37 per second."
               runbook_url: https://runbook.com/ingress-modsecurity-blocking
               dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/golden-signals/golden-signals?orgId=1&var-namespace=test-application-dev&var-service=test-application
 
   - interval: 1m
     input_series:
-      - series: 'nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-ingress", status="406"}'
+      - series: 'nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-v1-2", status="406"}'
         values: '0 20 38'
 
     name: ModSecurityBlocking alert not fired as request rate is equal to the threshold over the duration of the 1 minute time range window
@@ -246,7 +246,7 @@ tests:
     # this is here to help folks better understand the promql expression
     # at 2m the rate (increase per second) in the last minute: 0.3 ((38 - 20) / 60) which not greater than 0.33, assert nothing is returned
     promql_expr_test:
-      - expr: avg(rate(nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-ingress", status=~"406"}[1m]) > 0.33) by (ingress, exported_namespace)
+      - expr: avg(rate(nginx_ingress_controller_requests{exported_namespace="test-application-dev", ingress="test-application-v1-2", status=~"406"}[1m]) > 0.33) by (ingress, exported_namespace)
         eval_time: 2m
         exp_samples: []
 

--- a/charts/generic-prometheus-alerts/templates/application-alerts.yaml
+++ b/charts/generic-prometheus-alerts/templates/application-alerts.yaml
@@ -20,10 +20,10 @@ spec:
       rules:
         - alert: KubePodCrashLooping
           annotations:
+            summary: Pod is crash looping.
             message: Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} ({{`{{`}} $labels.container {{`}}`}}) is restarting {{`{{`}} printf "%.2f" $value {{`}}`}} times every 5 minutes.
             runbook_url: {{ .Values.runbookUrl }}application-pod-crashlooping
-            dashboard_url: {{ $.Values.grafanaUrl }}/d/application-alerts/application-alerts?orgId=1&var-namespace={{ $targetNamespace }}
-            summary: Pod is crash looping.
+            dashboard_url: {{ $.Values.grafanaUrl }}/d/golden-signals/golden-signals?orgId=1&var-namespace={{ $targetNamespace }}&var-service={{ $targetApplication }}
           expr: |
             rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", pod=~"{{ $targetPod }}"}[10m]) * 60 * 5 > 0
             {{ $businessOrAllHoursExpression }}
@@ -33,10 +33,10 @@ spec:
 
         - alert: KubePodNotReady
           annotations:
+            summary: Pod in a non-ready state.
             message: Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} has been in a non-ready state for longer than 15 minutes.
             runbook_url: {{ .Values.runbookUrl }}application-pod-notready
-            dashboard_url: {{ $.Values.grafanaUrl }}/d/application-alerts/application-alerts?orgId=1&var-namespace={{ $targetNamespace }}
-            summary: Pod has been in a non-ready state for more than 15 minutes.
+            dashboard_url: {{ $.Values.grafanaUrl }}/d/golden-signals/golden-signals?orgId=1&var-namespace={{ $targetNamespace }}&var-service={{ $targetApplication }}
           expr: |-
             sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", pod=~"{{ $targetPod }}", phase=~"Pending|Unknown"}) > 0
             {{ $businessOrAllHoursExpression }}
@@ -46,10 +46,10 @@ spec:
 
         - alert: KubeDeploymentGenerationMismatch
           annotations:
+            summary: Deployment generation mismatch.
             message: Deployment generation for {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.deployment {{`}}`}} does not match, this indicates that the Deployment has failed but has not been rolled back.
             runbook_url: {{ .Values.runbookUrl }}application-deployment-generation-mismatch
-            dashboard_url: {{ $.Values.grafanaUrl }}/d/application-alerts/application-alerts?orgId=1&var-namespace={{ $targetNamespace }}
-            summary: Deployment generation mismatch due to possible roll-back
+            dashboard_url: {{ $.Values.grafanaUrl }}/d/golden-signals/golden-signals?orgId=1&var-namespace={{ $targetNamespace }}&var-service={{ $targetApplication }}
           expr: |-
             (kube_deployment_status_observed_generation{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", deployment=~"{{ $targetDeployment }}"}
               !=
@@ -61,10 +61,10 @@ spec:
 
         - alert: KubeDeploymentReplicasMismatch
           annotations:
+            summary: Deployment has not matched the expected number of replicas.
             message: Deployment {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.deployment {{`}}`}} has not matched the expected number of replicas for longer 15 minutes.
             runbook_url: {{ .Values.runbookUrl }}application-deployment-replicas-mismatch
-            dashboard_url: {{ $.Values.grafanaUrl }}/d/application-alerts/application-alerts?orgId=1&var-namespace={{ $targetNamespace }}
-            summary: Deployment has not matched the expected number of replicas.
+            dashboard_url: {{ $.Values.grafanaUrl }}/d/golden-signals/golden-signals?orgId=1&var-namespace={{ $targetNamespace }}&var-service={{ $targetApplication }}
           expr: |-
             (kube_deployment_spec_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", deployment=~"{{ $targetDeployment }}"}
               !=
@@ -76,10 +76,10 @@ spec:
 
         - alert: KubeContainerWaiting
           annotations:
-            description: Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} container {{`{{`}} $labels.container {{`}}`}} has been in waiting state for longer than 1 hour.
+            summary: Pod container waiting.
+            message: Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} container {{`{{`}} $labels.container {{`}}`}} has been in waiting state for longer than 1 hour.
             runbook_url: {{ .Values.runbookUrl }}application-container-waiting
-            dashboard_url: {{ $.Values.grafanaUrl }}/d/application-alerts/application-alerts?orgId=1&var-namespace={{ $targetNamespace }}
-            summary: Pod container waiting longer than 1 hour
+            dashboard_url: {{ $.Values.grafanaUrl }}/d/golden-signals/golden-signals?orgId=1&var-namespace={{ $targetNamespace }}&var-service={{ $targetApplication }}
           expr: |
             sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", pod=~"{{ $targetPod }}"}) > 0
             {{ $businessOrAllHoursExpression }}
@@ -119,10 +119,10 @@ spec:
             {{ $businessOrAllHoursExpression }}
         - alert: CronJobStatusFailed
           annotations:
+            summary: CronJob is failing.
             message: CronJob {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.cronjob {{`}}`}} is failing.
             runbook_url: {{ .Values.runbookUrl }}application-cronjob-failed
-            dashboard_url: {{ $.Values.grafanaUrl }}/d/application-alerts/application-alerts?orgId=1&var-namespace={{ $targetNamespace }}
-            summary: CronJob is failing.
+            dashboard_url: {{ $.Values.grafanaUrl }}/d/golden-signals/golden-signals?orgId=1&var-namespace={{ $targetNamespace }}&var-service={{ $targetApplication }}
           expr: |
             (count_over_time(job:kube_job_status_failed_{{ $targetNamespaceUnderscore }}:sum[{{ .Values.applicationCronJobStatusFailedWindowMinutes }}m])
             * ON(cronjob,namespace) GROUP_LEFT()
@@ -133,10 +133,10 @@ spec:
 
         - alert: KubeHpaReplicasMismatch
           annotations:
-            description: HPA {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.hpa {{`}}`}} has not matched the desired number of replicas for longer than 15 minutes.
-            runbook_url: {{ .Values.runbookUrl }}application-hpa-replicas-mismatch
-            dashboard_url: {{ $.Values.grafanaUrl }}/d/application-alerts/application-alerts?orgId=1&var-namespace={{ $targetNamespace }}
             summary: HPA has not matched desired number of replicas.
+            message: HPA {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.hpa {{`}}`}} has not matched the desired number of replicas for longer than 15 minutes.
+            runbook_url: {{ .Values.runbookUrl }}application-hpa-replicas-mismatch
+            dashboard_url: {{ $.Values.grafanaUrl }}/d/golden-signals/golden-signals?orgId=1&var-namespace={{ $targetNamespace }}&var-service={{ $targetApplication }}
           expr: |
             ((kube_hpa_status_desired_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", hpa=~"{{ $targetHpa }}"}
               !=
@@ -158,10 +158,10 @@ spec:
 
         - alert: KubeHpaMaxedOut
           annotations:
-            description: HPA {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.hpa {{`}}`}} has been running at max replicas for longer than 15 minutes.
-            runbook_url: {{ .Values.runbookUrl }}application-hpa-maxed-out
-            dashboard_url: {{ $.Values.grafanaUrl }}/d/application-alerts/application-alerts?orgId=1&var-namespace={{ $targetNamespace }}
             summary: HPA is running at max replicas
+            message: HPA {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.hpa {{`}}`}} has been running at max replicas for longer than 15 minutes.
+            runbook_url: {{ .Values.runbookUrl }}application-hpa-maxed-out
+            dashboard_url: {{ $.Values.grafanaUrl }}/d/golden-signals/golden-signals?orgId=1&var-namespace={{ $targetNamespace }}&var-service={{ $targetApplication }}
           expr: |
             (kube_hpa_status_current_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", hpa=~"{{ $targetHpa }}"}
               ==
@@ -173,10 +173,10 @@ spec:
 
         - alert: KubeQuotaExceeded
           annotations:
+            summary: Namespace quota has exceeded the limits.
             message: Namespace {{`{{`}} $labels.namespace {{`}}`}} is using {{`{{`}} printf "%0.0f" $value {{`}}`}}% of its {{`{{`}} $labels.resource {{`}}`}} quota.
             runbook_url: {{ .Values.runbookUrl }}application-quota-exceeded
-            dashboard_url: {{ $.Values.grafanaUrl }}/d/application-alerts/application-alerts?orgId=1&var-namespace={{ $targetNamespace }}
-            summary: Namespace quota has exceeded the limits.
+            dashboard_url: {{ $.Values.grafanaUrl }}/d/golden-signals/golden-signals?orgId=1&var-namespace={{ $targetNamespace }}&var-service={{ $targetApplication }}
           expr: |-
             (100 * kube_resourcequota{namespace=~"{{ $targetNamespace }}", job="kube-state-metrics", type="used"}
               / ignoring(instance, job, type)
@@ -189,10 +189,10 @@ spec:
 
         - alert: KubeContainerOOMKilled
           annotations:
+            summary: Kubernetes container OOM killed.
             message: "Container {{`{{`}} $labels.container {{`}}`}} in pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} has been OOM Killed (out of memory) {{`{{`}} $value {{`}}`}} times in the last 10 minutes."
             runbook_url: {{ .Values.runbookUrl }}application-container-oom-killed
-            dashboard_url: {{ $.Values.grafanaUrl }}/d/application-alerts/application-alerts?orgId=1&var-namespace={{ $targetNamespace }}
-            summary: Kubernetes container OOM killed (instance {{`{{`}} $labels.instance {{`}}`}})
+            dashboard_url: {{ $.Values.grafanaUrl }}/d/golden-signals/golden-signals?orgId=1&var-namespace={{ $targetNamespace }}&var-service={{ $targetApplication }}
           expr: |-
             ((kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", pod=~"{{ $targetPod }}"}
              - kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", pod=~"{{ $targetPod }}"} offset 10m >= 1)

--- a/charts/generic-prometheus-alerts/templates/application-alerts.yaml
+++ b/charts/generic-prometheus-alerts/templates/application-alerts.yaml
@@ -1,8 +1,8 @@
 {{- $targetNamespace := .Release.Namespace }}
 {{- $targetNamespaceUnderscore := .Release.Namespace | replace "-" "_" }}
 {{- $targetApplication := required "A value for targetApplication must be set" .Values.targetApplication }}
-{{- $targetApplicationRegex := printf "%s.*" .Values.targetApplication }}
-{{- $targetPod := default $targetApplicationRegex .Values.podTargetOverride }}
+{{- $targetPodRegex := printf "%s(-[a-z0-9]{10}-[a-z0-9]{5})" .Values.targetApplication }}
+{{- $targetPod := default $targetPodRegex .Values.podTargetOverride }}
 {{- $targetDeployment := default .Values.targetApplication .Values.deploymentTargetOverride }}
 {{- $targetHpa := default .Values.targetApplication .Values.hpaTargetOverride }}
 {{- $targetApplicationBusinessHours := printf "and ON() %s:business_hours" .Values.targetApplication | replace "-" "_" }}

--- a/charts/generic-prometheus-alerts/templates/application-alerts.yaml
+++ b/charts/generic-prometheus-alerts/templates/application-alerts.yaml
@@ -1,7 +1,7 @@
 {{- $targetNamespace := .Release.Namespace }}
 {{- $targetNamespaceUnderscore := .Release.Namespace | replace "-" "_" }}
 {{- $targetApplication := required "A value for targetApplication must be set" .Values.targetApplication }}
-{{- $targetPodRegex := printf "%s(-[a-z0-9]{10}-[a-z0-9]{5})" .Values.targetApplication }}
+{{- $targetPodRegex := printf "%s(-[a-z0-9]{4,10}-[a-z0-9]{5})" .Values.targetApplication }}
 {{- $targetPod := default $targetPodRegex .Values.podTargetOverride }}
 {{- $targetDeployment := default .Values.targetApplication .Values.deploymentTargetOverride }}
 {{- $targetHpa := default .Values.targetApplication .Values.hpaTargetOverride }}

--- a/charts/generic-prometheus-alerts/templates/aws-elasticache-alerts.yaml
+++ b/charts/generic-prometheus-alerts/templates/aws-elasticache-alerts.yaml
@@ -25,10 +25,10 @@ spec:
         {{- range $clusterId, $displayName := $.Values.elastiCacheAlertsClusterIds }}
         - alert: elasticache-enginecpu-utilisation
           annotations:
-            message: elasticache cluster {{ $clusterId }} in {{ $targetNamespace }} - EngineCPU utilisation at {{`{{`}} printf "%.2f" $value {{`}}`}} which is over threshold of {{ $elastiCacheAlertsEngineCPUThreshold }} for last {{ $elastiCacheAlertsEngineCPUThresholdMinutes }} mins. This alert configured by app {{ $targetNamespace }}/{{ $targetApplication }}.
+            summary: ElastiCache cluster EngineCPU usage too high.
+            message: ElastiCache cluster {{ $clusterId }} in {{ $targetNamespace }} - EngineCPU utilisation at {{`{{`}} printf "%.2f" $value {{`}}`}} which is over threshold of {{ $elastiCacheAlertsEngineCPUThreshold }} for last {{ $elastiCacheAlertsEngineCPUThresholdMinutes }} mins. This alert configured by app {{ $targetNamespace }}/{{ $targetApplication }}.
             runbook_url: {{ $.Values.runbookUrl }}elasticache-enginecpu-utilisation
             dashboard_url: {{ $.Values.grafanaUrl }}/d/nK7rpiQZk/aws-elasticache-redis?orgId=1&var-cacheclusterId={{ $clusterId }}&from=now-6h&to=now
-            summary: elasticache cluster EngineCPU usage too high
           expr: |-
             aws_elasticache_engine_cpuutilization_average{cache_cluster_id='{{ $clusterId }}'} offset {{ $elastiCacheAlertsEngineCPUThresholdMinutes }}m > {{ $elastiCacheAlertsEngineCPUThreshold }}
             {{ $businessOrAllHoursExpression }}
@@ -38,10 +38,10 @@ spec:
 
         - alert: elasticache-cpu-utilisation
           annotations:
-            message: elasticache cluster {{ $clusterId }} in {{ $targetNamespace }} - CPU utilisation at {{`{{`}} printf "%.2f" $value {{`}}`}} which is over threshold of {{ $elastiCacheAlertsCPUThreshold }} for last {{ $elastiCacheAlertsCPUThresholdMinutes }} mins. This alert configured by app {{ $targetNamespace }}/{{ $targetApplication }}.
+            summary: ElastiCache cluster CPU usage too high.
+            message: ElastiCache cluster {{ $clusterId }} in {{ $targetNamespace }} - CPU utilisation at {{`{{`}} printf "%.2f" $value {{`}}`}} which is over threshold of {{ $elastiCacheAlertsCPUThreshold }} for last {{ $elastiCacheAlertsCPUThresholdMinutes }} mins. This alert configured by app {{ $targetNamespace }}/{{ $targetApplication }}.
             runbook_url: {{ $.Values.runbookUrl }}elasticache-cpu-utilisation
             dashboard_url: {{ $.Values.grafanaUrl }}/d/nK7rpiQZk/aws-elasticache-redis?orgId=1&var-cacheclusterId={{ $clusterId }}&from=now-6h&to=now
-            summary: elasticache cluster CPU usage too high
           expr: |-
             aws_elasticache_cpuutilization_average{cache_cluster_id='{{ $clusterId }}'} offset {{ $elastiCacheAlertsCPUThresholdMinutes }}m > {{ $elastiCacheAlertsCPUThreshold }}
             {{ $businessOrAllHoursExpression }}
@@ -51,10 +51,10 @@ spec:
 
         - alert: elasticache-freeable-memory
           annotations:
-            message: elasticache cluster {{ $clusterId }} in {{ $targetNamespace }} - freeable memory at {{`{{`}} printf "%.2f" $value {{`}}`}} which is below threshold of {{ $elastiCacheAlertsFreeMemoryThreshold }} for last {{ $elastiCacheAlertsFreeMemoryThresholdMinutes }} mins. This alert configured by app {{ $targetNamespace }}/{{ $targetApplication }}.
+            summary: ElastiCache cluster freeable memory too low.
+            message: ElastiCache cluster {{ $clusterId }} in {{ $targetNamespace }} - freeable memory at {{`{{`}} printf "%.2f" $value {{`}}`}} which is below threshold of {{ $elastiCacheAlertsFreeMemoryThreshold }} for last {{ $elastiCacheAlertsFreeMemoryThresholdMinutes }} mins. This alert configured by app {{ $targetNamespace }}/{{ $targetApplication }}.
             runbook_url: {{ $.Values.runbookUrl }}elasticache-memory-utilisation
             dashboard_url: {{ $.Values.grafanaUrl }}/d/nK7rpiQZk/aws-elasticache-redis?orgId=1&var-cacheclusterId={{ $clusterId }}&from=now-6h&to=now
-            summary: elasticache cluster freeable memory too low
           expr: |-
             (aws_elasticache_freeable_memory_average{cache_cluster_id='{{ $clusterId }}'} offset 5m)/1000000 < {{ $elastiCacheAlertsFreeMemoryThreshold }}
             {{ $businessOrAllHoursExpression }}
@@ -64,10 +64,10 @@ spec:
 
         - alert: elasticache-memory-utilisation
           annotations:
-            message: elasticache cluster {{ $clusterId }} in {{ $targetNamespace }} - memory utilisation at {{`{{`}} printf "%.2f" $value {{`}}`}} which is over threshold of {{ $elastiCacheAlertsMemoryUsageThreshold }} for last {{ $elastiCacheAlertsMemoryUsageThresholdMinutes }} mins. This alert configured by app {{ $targetNamespace }}/{{ $targetApplication }}.
+            summary: ElastiCache cluster memory usage too high.
+            message: ElastiCache cluster {{ $clusterId }} in {{ $targetNamespace }} - memory utilisation at {{`{{`}} printf "%.2f" $value {{`}}`}} which is over threshold of {{ $elastiCacheAlertsMemoryUsageThreshold }} for last {{ $elastiCacheAlertsMemoryUsageThresholdMinutes }} mins. This alert configured by app {{ $targetNamespace }}/{{ $targetApplication }}.
             runbook_url: {{ $.Values.runbookUrl }}elasticache-memory-utilisation
             dashboard_url: {{ $.Values.grafanaUrl }}/d/nK7rpiQZk/aws-elasticache-redis?orgId=1&var-cacheclusterId={{ $clusterId }}&from=now-6h&to=now
-            summary: elasticache cluster memory usage too high
           expr: |-
             aws_elasticache_database_memory_usage_percentage_average{cache_cluster_id='{{ $clusterId }}'} offset {{ $elastiCacheAlertsMemoryUsageThresholdMinutes }}m > {{ $elastiCacheAlertsMemoryUsageThreshold }}
             {{ $businessOrAllHoursExpression }}

--- a/charts/generic-prometheus-alerts/templates/aws-rds-alerts.yaml
+++ b/charts/generic-prometheus-alerts/templates/aws-rds-alerts.yaml
@@ -21,10 +21,10 @@ spec:
 {{- range $key, $val := $.Values.rdsAlertsDatabases }}
         - alert: rds-cpu-utilisation
           annotations:
+            summary: RDS CPU usage too high
             message: RDS database {{ $val }} in {{ $targetNamespace }} - CPU utilisation at {{`{{`}} printf "%.2f" $value {{`}}`}} which is over threshold of {{ $rdsAlertsCPUThreshold }} for last {{ $rdsAlertsCPUThresholdMinutes }} mins. This alert configured by app {{ $targetNamespace }}/{{ $targetApplication }}.
             runbook_url: {{ $.Values.runbookUrl }}rds-cpu-utilisation
             dashboard_url: {{ $.Values.grafanaUrl }}/d/VR46pmwWk/aws-rds?orgId=1&var-datasource=Cloudwatch&var-region=default&var-dbinstanceidentifier={{ $key }}&from=now-6h&to=now
-            summary: RDS CPU usage too high
           expr: |-
             aws_rds_cpuutilization_average{dbinstance_identifier='{{ $key }}'} > {{ $rdsAlertsCPUThreshold }}
             {{ $businessOrAllHoursExpression }}
@@ -34,10 +34,10 @@ spec:
 
         - alert: rds-connection-count
           annotations:
+            summary: Too many RDS connections
             message: RDS database {{ $val }} in {{ $targetNamespace }} - there are {{`{{`}} $value {{`}}`}} connections which is over threshold of {{ $rdsAlertsConnectionThreshold }} for last {{ $rdsAlertsConnectionThresholdMinutes }} mins. This alert configured by app {{ $targetNamespace }}/{{ $targetApplication }}.
             runbook_url: {{ $.Values.runbookUrl }}rds-connection-count
             dashboard_url: {{ $.Values.grafanaUrl }}/d/VR46pmwWk/aws-rds?orgId=1&var-datasource=Cloudwatch&var-region=default&var-dbinstanceidentifier={{ $key }}&from=now-6h&to=now
-            summary: Too many RDS connections
           expr: |-
             aws_rds_database_connections_average{dbinstance_identifier='{{ $key }}'} > {{ $rdsAlertsConnectionThreshold }}
             {{ $businessOrAllHoursExpression }}

--- a/charts/generic-prometheus-alerts/templates/aws-sns-alerts.yaml
+++ b/charts/generic-prometheus-alerts/templates/aws-sns-alerts.yaml
@@ -18,6 +18,7 @@ spec:
 {{- range $key, $val := $.Values.snsAlertsTopicNames }}
         - alert: SNS-no-messages-published
           annotations:
+            summary: SNS topic no messages published.
             message: "SNS topic {{ $val }} - no messages published in last {{ $snsAlertsNoMessagesThresholdMinutes }} mins, check the producer(s). This alert configured by app {{ $targetNamespace }}/{{ $targetApplication }}."
             runbook_url: {{ $.Values.runbookUrl }}sns-no-messages-published
             dashboard_url: {{ $.Values.grafanaUrl }}/d/AWSSNS001/aws-sns?orgId=1&var-datasource=Cloudwatch&var-region=default&var-topic={{ $key }}&from=now-6h&to=now

--- a/charts/generic-prometheus-alerts/templates/aws-sqs-alerts.yaml
+++ b/charts/generic-prometheus-alerts/templates/aws-sqs-alerts.yaml
@@ -24,6 +24,7 @@ spec:
 {{ if $sqsOldestAlertQueueNames }}
         - alert: SQS-oldest-message
           annotations:
+            summary: SQS oldest message alert.
             message: "SQS - {{ $sqsLabelQueueName }} has message older than {{ $sqsAlertsOldestThreshold }} mins, check consumers are healthy. This alert configured by app {{ $targetNamespace }}/{{ $targetApplication }}."
             runbook_url: {{ $.Values.runbookUrl }}sqs-oldest-message
             dashboard_url: {{ $.Values.grafanaUrl }}/d/AWSSQS000/aws-sqs?orgId=1&var-datasource=Cloudwatch&var-region=default&var-queue={{ $sqsLabelQueueName }}&from=now-6h&to=now
@@ -37,6 +38,7 @@ spec:
 {{ if $sqsNumberAlertQueueNames }}
         - alert: SQS-number-of-messages
           annotations:
+            summary: SQS number of messages alert.
             message: SQS - {{ $sqsLabelQueueName }} - number of messages={{`{{`}} $value {{`}}`}} (exceeds {{ $sqsAlertsTotalMessagesThreshold }}), check consumers are healthy.
             runbook_url: {{ $.Values.runbookUrl }}sqs-number-of-messages
             dashboard_url: {{ $.Values.grafanaUrl }}/d/AWSSQS000/aws-sqs?orgId=1&var-datasource=Cloudwatch&var-region=default&var-queue={{ $sqsLabelQueueName }}&from=now-6h&to=now
@@ -50,6 +52,7 @@ spec:
 {{ range $key, $queues := $sqsNumberAlertQueueMappings }}
         - alert: SQS-number-of-messages-{{ $key }}
           annotations:
+            summary: SQS number of messages alert.
             message: SQS - {{ $sqsLabelQueueName }} - number of messages={{`{{`}} $value {{`}}`}} (exceeds {{ $sqsAlertsTotalMessagesThreshold }}), check consumers are healthy.
             runbook_url: {{ $.Values.runbookUrl }}sqs-number-of-messages
             dashboard_url: {{ $.Values.grafanaUrl }}/d/AWSSQS000/aws-sqs?orgId=1&var-datasource=Cloudwatch&var-region=default&var-queue={{ $sqsLabelQueueName }}&from=now-6h&to=now

--- a/charts/generic-prometheus-alerts/templates/ingress-alerts.yaml
+++ b/charts/generic-prometheus-alerts/templates/ingress-alerts.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingressAlertsEnabled -}}
 {{- $targetNamespace := .Release.Namespace }}
 {{- $targetApplication := required "A value for targetApplication must be set" .Values.targetApplication }}
-{{- $defaultTargetIngress := print .Values.targetApplication ".*" }}
+{{- $defaultTargetIngress := print .Values.targetApplication "(-v1-2)" }}
 {{- $targetIngress := default $defaultTargetIngress .Values.ingressTargetOverride }}
 {{- $modSecBlockingStatusCode := default "406" .Values.modSecBlockingStatusCodeOverride }}
 {{- $targetApplicationBusinessHours := printf "and ON() %s:business_hours" .Values.targetApplication | replace "-" "_" }}

--- a/charts/generic-prometheus-alerts/templates/ingress-alerts.yaml
+++ b/charts/generic-prometheus-alerts/templates/ingress-alerts.yaml
@@ -19,9 +19,10 @@ spec:
       rules:
         - alert: 5xxErrorResponses
           annotations:
+            summary: Ingress serving 5xx responses.
             message: Ingress {{`{{`}} $labels.exported_namespace {{`}}`}}/{{`{{`}} $labels.ingress {{`}}`}} is serving 5xx responses.
             runbook_url: {{ .Values.runbookUrl }}ingress-5xx-error-responses
-            dashboard_url: {{ $.Values.grafanaUrl }}/d/{{ $.Values.dashboardId }}/kubernetes-ingress-traffic?{{ $.Values.orgId }}&var-namespace={{ $targetNamespace }}&var-ingress={{ $targetIngress }}&from=now-5m&to=now                                                                                                                                                                             
+            dashboard_url: {{ $.Values.grafanaUrl }}/d/golden-signals/golden-signals?orgId=1&var-namespace={{ $targetNamespace }}&var-service={{ $targetApplication }}
           expr: |-
             avg(rate(nginx_ingress_controller_requests{exported_namespace=~"{{ $targetNamespace }}", ingress=~"{{ $targetIngress }}", path="/", status=~"5.*"}[{{ .Values.ingress5xxErrorWindowMinutes }}m]) > 0) by (ingress, exported_namespace)
             {{ $businessOrAllHoursExpression }}
@@ -32,9 +33,10 @@ spec:
 {{- if .Values.ingress2xxEnabled }}
         - alert: 2xxResponses
           annotations:
+            summary: Ingress not serving enough 2xx responses.
             message: Ingress {{`{{`}} $labels.exported_namespace {{`}}`}}/{{`{{`}} $labels.ingress {{`}}`}} is not serving enough 2xx responses.
             runbook_url: {{ .Values.runbookUrl }}ingress-2xx-responses
-            dashboard_url: {{ $.Values.grafanaUrl }}/d/{{ $.Values.dashboardId }}/kubernetes-ingress-traffic?{{ $.Values.orgId }}&var-namespace={{ $targetNamespace }}&var-ingress={{ $targetIngress }}&from=now-2h&to=now
+            dashboard_url: {{ $.Values.grafanaUrl }}/d/golden-signals/golden-signals?orgId=1&var-namespace={{ $targetNamespace }}&var-service={{ $targetApplication }}
           expr: |-
             sum by (ingress, exported_namespace) (increase(nginx_ingress_controller_requests{exported_namespace=~"{{ $targetNamespace }}",ingress=~"{{ $targetIngress }}",path="/",status=~"2.*"}[{{ .Values.ingress2xxWindowMinutes }}m])) < {{ .Values.ingress2xxThreshold }}
             {{ $businessOrAllHoursExpression }}
@@ -45,9 +47,10 @@ spec:
 {{- end }}
         - alert: 5xxErrorResponsesOnHealthEndpoint
           annotations:
+            summary: High rate of 5xx errors on /health.
             message: High rate of 5xx errors detected on /health path in Ingress {{`{{`}} $labels.exported_namespace {{`}}`}}/{{`{{`}} $labels.ingress {{`}}`}}.
             runbook_url: {{ .Values.runbookUrl }}ingress-5xx-error-responses
-            dashboard_url: {{ $.Values.grafanaUrl }}/d/{{ $.Values.dashboardId }}/kubernetes-ingress-traffic?{{ $.Values.orgId }}&var-namespace={{ $targetNamespace }}&var-ingress={{ $targetIngress }}&from=now-5m&to=now
+            dashboard_url: {{ $.Values.grafanaUrl }}/d/golden-signals/golden-signals?orgId=1&var-namespace={{ $targetNamespace }}&var-service={{ $targetApplication }}
           expr: |-
             avg(rate(nginx_ingress_controller_requests{exported_namespace=~"{{ $targetNamespace }}", ingress=~"{{ $targetIngress }}", path="/health", status=~"5.*"}[{{ .Values.ingress5xxErrorWindowMinutesHealthEndpoint }}m]) > {{ .Values.ingress5xxHealthEndpointThreshold }}) by (ingress, exported_namespace)
             {{ $businessOrAllHoursExpression }}
@@ -57,6 +60,7 @@ spec:
 
         - alert: RatelimitBlocking
           annotations:
+            summary: Ingress is being rate limited.
             message: Rate limit is being applied on ingress {{`{{`}} $labels.exported_namespace {{`}}`}}/{{`{{`}} $labels.ingress {{`}}`}}.
             runbook_url: {{ .Values.runbookUrl }}ingress-rate-limiting
             dashboard_url: {{ $.Values.grafanaUrl }}/d/golden-signals/golden-signals?orgId=1&var-namespace={{ $targetNamespace }}&var-service={{ $targetApplication }}
@@ -69,6 +73,7 @@ spec:
 
         - alert: ModSecurityBlocking
           annotations:
+            summary: Mod_Security blocking ingress.
             message: Mod_Security is blocking ingress {{`{{`}} $labels.exported_namespace {{`}}`}}/{{`{{`}} $labels.ingress {{`}}`}}. Blocking http requests at rate of {{`{{`}} printf "%.2f" $value {{`}}`}} per second.
             runbook_url: {{ .Values.runbookUrl }}ingress-modsecurity-blocking
             dashboard_url: {{ $.Values.grafanaUrl }}/d/golden-signals/golden-signals?orgId=1&var-namespace={{ $targetNamespace }}&var-service={{ $targetApplication }}

--- a/charts/generic-prometheus-alerts/values.yaml
+++ b/charts/generic-prometheus-alerts/values.yaml
@@ -20,7 +20,6 @@ businessUnit: hmpps
 
 runbookUrl: https://github.com/ministryofjustice/hmpps-helm-charts/blob/main/charts/generic-prometheus-alerts/RUNBOOK.md#
 grafanaUrl: https://grafana.live.cloud-platform.service.justice.gov.uk
-dashboardId: f1e13059dfd23fdcaf479f4fa833f92610c2dfa5
 orgId: 1
 
 # Alert by default will target resources uses a regex and the application name (.Values.targetApplication).


### PR DESCRIPTION
Update application rules regex:
  - the regex used to match against pods is now more precise.
  - now matching the standard k8s pod naming (for a deployment/replicaset) which
    includes random characters.
    e.g. [deployment-name]-[random 4-10 alpha chars]-[random 5 alpha chars]

See https://github.com/kubernetes/kubernetes/issues/121687  - for discussion on the length of the length of random chars in the ReplicaSet name.  I've decided on minimum of 4 chars as safe bet that we get a match in prometheus.  The issue suggest matching on `ownerReferences ` however these are not available to in prometheus.
