### PR TITLE
PI-3145 Alerts for OpenSearch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 default: build
 
 ci_dir="charts/generic-prometheus-alerts/ci"
-objects=rules app ingress rds sns sqs
+objects=rules app ingress rds sns sqs opensearch
 apps=test-application test-business-hours
 group_names=$(foreach app,$(apps),$(addprefix $(app)-,$(objects)))
 

--- a/charts/generic-prometheus-alerts/Chart.yaml
+++ b/charts/generic-prometheus-alerts/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.11.7
+version: 1.12.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/generic-prometheus-alerts/ci/test-application/values.yaml
+++ b/charts/generic-prometheus-alerts/ci/test-application/values.yaml
@@ -7,5 +7,7 @@ generic-prometheus-alerts:
     cloud-platform-uuid: "test rds"
   sqsAlertsQueueNames:
     - "queue-name"
+  openSearchAlertsDomainNames:
+    cloud-platform-uuid: "test-domain"
   businessHoursOnly: false
   ingress2xxEnabled: true

--- a/charts/generic-prometheus-alerts/ci/test-business-hours/values.yaml
+++ b/charts/generic-prometheus-alerts/ci/test-business-hours/values.yaml
@@ -7,4 +7,6 @@ generic-prometheus-alerts:
     cloud-platform-uuid: "test rds"
   sqsAlertsQueueNames:
     - "queue-name"
+  openSearchAlertsDomainNames:
+    cloud-platform-uuid: "test-domain"
   businessHoursOnly: true

--- a/charts/generic-prometheus-alerts/ci/tests/aws-opensearch-alerts-tests.yaml
+++ b/charts/generic-prometheus-alerts/ci/tests/aws-opensearch-alerts-tests.yaml
@@ -1,0 +1,129 @@
+---
+rule_files:
+  - ../test-application-opensearch.yaml
+  - ../test-business-hours-opensearch.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    name: OpenSearchClusterStatusRed alert fires when cluster status is red for configured duration
+    input_series:
+      - series: 'aws_es_cluster_status_red_maximum{domain_name="cloud-platform-uuid"}'
+        values: '0 0 0 0 1' # Red for 1 minute
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: OpenSearchClusterStatusRed
+        exp_alerts:
+          - exp_labels:
+              alertname: OpenSearchClusterStatusRed
+              application: test-application
+              businessUnit: hmpps
+              domain_name: cloud-platform-uuid
+              environment: none
+              productId: none
+              severity: alert-severity-tag
+            exp_annotations:
+              summary: OpenSearch cluster status is red
+              message: test-domain in test-application-dev - Cluster status is red. At least one primary shard and its replicas are not allocated to a node.
+              dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/eCN_s8yWk/aws-elasticsearch?orgId=1&var-domainName=cloud-platform-uuid&from=now-6h&to=now
+              runbook_url: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/handling-errors.html#handling-errors-red-cluster-status
+
+  - interval: 1m
+    name: OpenSearchClusterStatusYellow alert fires when cluster status is yellow for configured duration
+    input_series:
+      - series: 'aws_es_cluster_status_yellow_maximum{domain_name="cloud-platform-uuid"}'
+        values: '0 0 0 0 0 1 1 1 1 1' # Yellow for 5 minutes
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: OpenSearchClusterStatusYellow
+        exp_alerts:
+          - exp_labels:
+              alertname: OpenSearchClusterStatusRed
+              application: test-application
+              businessUnit: hmpps
+              domain_name: cloud-platform-uuid
+              environment: none
+              productId: none
+              severity: alert-severity-tag
+            exp_annotations:
+              summary: OpenSearch cluster status is yellow
+              message: test-domain in test-application-dev - Cluster status is yellow. At least one replica shard is not allocated to a node.
+              dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/eCN_s8yWk/aws-elasticsearch?orgId=1&var-domainName=cloud-platform-uuid&from=now-6h&to=now
+              runbook_url: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/handling-errors.html#handling-errors-yellow-cluster-status
+
+  - interval: 1m
+    name: OpenSearchFreeStorageSpace alert fires when free storage space is low for configured duration
+    input_series:
+      - series: 'aws_es_free_storage_space_minimum{domain_name="cloud-platform-uuid", node_id="node1"}'
+        values: '25000 25000 25000 25000 500' # Below 20GB for 1 minute
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: OpenSearchFreeStorageSpace
+        exp_alerts:
+          - exp_labels:
+              alertname: OpenSearchClusterStatusRed
+              application: test-application
+              businessUnit: hmpps
+              domain_name: cloud-platform-uuid
+              environment: none
+              node_id: node1
+              productId: none
+              severity: alert-severity-tag
+            exp_annotations:
+              summary: OpenSearch free storage space is low
+              message: test-domain in test-application-dev - A node in your cluster has less than 20 GiB of free storage space.
+              dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/eCN_s8yWk/aws-elasticsearch?orgId=1&var-domainName=cloud-platform-uuid&from=now-6h&to=now
+              runbook_url: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/handling-errors.html#handling-errors-watermark
+
+  - interval: 1m
+    name: OpenSearchAutomatedSnapshotFailure alert fires when automated snapshot fails for configured duration
+    input_series:
+      - series: 'aws_es_automated_snapshot_failure_maximum{domain_name="cloud-platform-uuid", node_id="node1"}'
+        values: '0 0 0 0 1' # Failed for 1 minute
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: OpenSearchAutomatedSnapshotFailure
+        exp_alerts:
+          - exp_labels:
+              alertname: OpenSearchClusterStatusRed
+              application: test-application
+              businessUnit: hmpps
+              domain_name: cloud-platform-uuid
+              environment: none
+              node_id: node1
+              productId: none
+              severity: alert-severity-tag
+            exp_annotations:
+              summary: OpenSearch automated snapshot failed
+              message: test-domain in test-application-dev - An automated snapshot failed. This failure is often the result of a red cluster health status.
+              dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/eCN_s8yWk/aws-elasticsearch?orgId=1&var-domainName=cloud-platform-uuid&from=now-6h&to=now
+              runbook_url: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/handling-errors.html#handling-errors-red-cluster-status
+
+  - interval: 1m
+    name: OpenSearchJVMMemoryPressure alert fires when JVM memory pressure is too high for configured duration
+    input_series:
+      - series: 'aws_es_jvmmemory_pressure_maximum{domain_name="cloud-platform-uuid", node_id="node1"}'
+        values: '50 50 99 99 99' # 99% for 3 minutes
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: OpenSearchJVMMemoryPressure
+        exp_alerts:
+          - exp_labels:
+              alertname: OpenSearchJVMMemoryPressure
+              application: test-application
+              businessUnit: hmpps
+              domain_name: cloud-platform-uuid
+              environment: none
+              node_id: node1
+              productId: none
+              severity: alert-severity-tag
+            exp_annotations:
+              summary: OpenSearch JVM memory pressure is too high
+              message: test-domain in test-application-dev - High JVM memory pressure. The cluster could encounter out of memory errors if usage increases. Consider scaling vertically.
+              dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/eCN_s8yWk/aws-elasticsearch?orgId=1&var-domainName=cloud-platform-uuid&from=now-6h&to=now

--- a/charts/generic-prometheus-alerts/templates/aws-opensearch-alerts.yaml
+++ b/charts/generic-prometheus-alerts/templates/aws-opensearch-alerts.yaml
@@ -1,0 +1,119 @@
+{{- if .Values.openSearchAlertsDomainNames -}}
+{{- $targetNamespace := .Release.Namespace }}
+{{- $targetApplication := required "A value for targetApplication must be set" .Values.targetApplication }}
+{{- $openSearchAlertsCPUThreshold := .Values.openSearchAlertsCPUThreshold }}
+{{- $openSearchAlertsCPUThresholdMinutes := .Values.openSearchAlertsCPUThresholdMinutes }}
+{{- $openSearchAlertsClusterIndexWritesBlockedMinutes := .Values.openSearchAlertsClusterIndexWritesBlockedMinutes }}
+{{- $openSearchAlertsClusterStatusRedMinutes := .Values.openSearchAlertsClusterStatusRedMinutes }}
+{{- $openSearchAlertsClusterStatusYellowMinutes := .Values.openSearchAlertsClusterStatusYellowMinutes }}
+{{- $openSearchAlertsFreeStorageSpaceThresholdGB := .Values.openSearchAlertsFreeStorageSpaceThresholdGB }}
+{{- $openSearchAlertsFreeStorageSpaceThresholdMinutes := .Values.openSearchAlertsFreeStorageSpaceThresholdMinutes }}
+{{- $openSearchAlertsJVMMemoryPressureThreshold := .Values.openSearchAlertsJVMMemoryPressureThreshold }}
+{{- $openSearchAlertsJVMMemoryPressureThresholdMinutes := .Values.openSearchAlertsJVMMemoryPressureThresholdMinutes }}
+{{- $openSearchAlertsSnapshotFailureMinutes := .Values.openSearchAlertsSnapshotFailureMinutes }}
+{{- $targetApplicationBusinessHours := printf "and ON() %s:business_hours" .Values.targetApplication | replace "-" "_" }}
+{{- $businessOrAllHoursExpression := ternary $targetApplicationBusinessHours "" .Values.businessHoursOnly}}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ $targetApplication }}-opensearch
+  labels:
+    {{ include "generic-prometheus-alerts.labels" . | nindent 4 }}
+spec:
+  groups:
+    - name: {{ $targetApplication }}-opensearch
+      rules:
+        {{- range $domainName, $displayName := $.Values.openSearchAlertsDomainNames }}
+        - alert: OpenSearchClusterStatusRed
+          annotations:
+            summary: OpenSearch cluster status is red
+            message: {{ $displayName }} in {{ $targetNamespace }} - Cluster status is red. At least one primary shard and its replicas are not allocated to a node.
+            runbook_url: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/handling-errors.html#handling-errors-red-cluster-status
+            dashboard_url: {{ $.Values.grafanaUrl }}/d/eCN_s8yWk/aws-elasticsearch?orgId=1&var-domainName={{ $domainName }}&from=now-6h&to=now
+          expr: |-
+            aws_es_cluster_status_red_maximum{domain_name='{{ $domainName }}'} >= 1
+            {{ $businessOrAllHoursExpression }}
+          for: {{ $openSearchAlertsClusterStatusRedMinutes }}m
+          labels:
+            {{ include "generic-prometheus-alerts.ruleLabels" $ | nindent 12 }}
+
+        - alert: OpenSearchClusterStatusYellow
+          annotations:
+            summary: OpenSearch cluster status is yellow
+            message: {{ $displayName }} in {{ $targetNamespace }} - Cluster status is yellow. At least one replica shard is not allocated to a node.
+            runbook_url: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/handling-errors.html#handling-errors-yellow-cluster-status
+            dashboard_url: {{ $.Values.grafanaUrl }}/d/eCN_s8yWk/aws-elasticsearch?orgId=1&var-domainName={{ $domainName }}&from=now-6h&to=now
+          expr: |-
+            aws_es_cluster_status_yellow_maximum{domain_name='{{ $domainName }}'} >= 1
+            {{ $businessOrAllHoursExpression }}
+          for: {{ $openSearchAlertsClusterStatusYellowMinutes }}m
+          labels:
+            {{ include "generic-prometheus-alerts.ruleLabels" $ | nindent 12 }}
+
+        - alert: OpenSearchFreeStorageSpace
+          annotations:
+            summary: OpenSearch free storage space is low
+            message: {{ $displayName }} in {{ $targetNamespace }} - A node in your cluster has less than {{ $openSearchAlertsFreeStorageSpaceThresholdGB }} GiB of free storage space.
+            runbook_url: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/handling-errors.html#handling-errors-watermark
+            dashboard_url: {{ $.Values.grafanaUrl }}/d/eCN_s8yWk/aws-elasticsearch?orgId=1&var-domainName={{ $domainName }}&from=now-6h&to=now
+          expr: |-
+            (aws_es_free_storage_space_minimum{domain_name='{{ $domainName }}', node_id != ""} > 0)
+            and
+            (aws_es_free_storage_space_minimum{domain_name='{{ $domainName }}', node_id != ""} < {{ $openSearchAlertsFreeStorageSpaceThresholdGB }} * 1024)
+            {{ $businessOrAllHoursExpression }}
+          for: {{ $openSearchAlertsFreeStorageSpaceThresholdMinutes }}m
+          labels:
+            {{ include "generic-prometheus-alerts.ruleLabels" $ | nindent 12 }}
+
+        - alert: OpenSearchIndexWritesBlocked
+          annotations:
+            summary: OpenSearch cluster index writes are blocked
+            message: {{ $displayName }} in {{ $targetNamespace }} - Your cluster is blocking write requests.
+            runbook_url: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/handling-errors.html#troubleshooting-cluster-block
+            dashboard_url: {{ $.Values.grafanaUrl }}/d/eCN_s8yWk/aws-elasticsearch?orgId=1&var-domainName={{ $domainName }}&from=now-6h&to=now
+          expr: |-
+            aws_es_cluster_index_writes_blocked_maximum{domain_name='{{ $domainName }}'} >= 1
+            {{ $businessOrAllHoursExpression }}
+          for: {{ $openSearchAlertsClusterIndexWritesBlockedMinutes }}m
+          labels:
+            {{ include "generic-prometheus-alerts.ruleLabels" $ | nindent 12 }}
+
+        - alert: OpenSearchAutomatedSnapshotFailure
+          annotations:
+            summary: OpenSearch automated snapshot failed
+            message: {{ $displayName }} in {{ $targetNamespace }} - An automated snapshot failed. This failure is often the result of a red cluster health status.
+            runbook_url: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/handling-errors.html#handling-errors-red-cluster-status
+            dashboard_url: {{ $.Values.grafanaUrl }}/d/eCN_s8yWk/aws-elasticsearch?orgId=1&var-domainName={{ $domainName }}&from=now-6h&to=now
+          expr: |-
+            aws_es_automated_snapshot_failure_maximum{domain_name='{{ $domainName }}'} >= 1
+            {{ $businessOrAllHoursExpression }}
+          for: {{ $openSearchAlertsSnapshotFailureMinutes }}m
+          labels:
+            {{ include "generic-prometheus-alerts.ruleLabels" $ | nindent 12 }}
+
+        - alert: OpenSearchCPUUtilisation
+          annotations:
+            summary: OpenSearch CPU usage too high
+            message: {{ $displayName }} in {{ $targetNamespace }} - Sustained high CPU usage. Consider using larger instance types or adding instances.
+            dashboard_url: {{ $.Values.grafanaUrl }}/d/eCN_s8yWk/aws-elasticsearch?orgId=1&var-domainName={{ $domainName }}&from=now-6h&to=now
+          expr: |-
+            aws_es_cpuutilization_maximum{domain_name='{{ $domainName }}', node_id != ""} > {{ $openSearchAlertsCPUThreshold }}
+            {{ $businessOrAllHoursExpression }}
+          for: {{ $openSearchAlertsCPUThresholdMinutes }}m
+          labels:
+            {{ include "generic-prometheus-alerts.ruleLabels" $ | nindent 12 }}
+
+        - alert: OpenSearchJVMMemoryPressure
+          annotations:
+            summary: OpenSearch JVM memory pressure is too high
+            message: {{ $displayName }} in {{ $targetNamespace }} - High JVM memory pressure. The cluster could encounter out of memory errors if usage increases. Consider scaling vertically.
+            dashboard_url: {{ $.Values.grafanaUrl }}/d/eCN_s8yWk/aws-elasticsearch?orgId=1&var-domainName={{ $domainName }}&from=now-6h&to=now
+          expr: |-
+            aws_es_jvmmemory_pressure_maximum{domain_name='{{ $domainName }}', node_id != ""} > {{ $openSearchAlertsJVMMemoryPressureThreshold }}
+            {{ $businessOrAllHoursExpression }}
+          for: {{ $openSearchAlertsJVMMemoryPressureThresholdMinutes }}m
+          labels:
+            {{ include "generic-prometheus-alerts.ruleLabels" $ | nindent 12 }}
+        {{- end }}
+{{- end }}

--- a/charts/generic-prometheus-alerts/values.yaml
+++ b/charts/generic-prometheus-alerts/values.yaml
@@ -168,3 +168,37 @@ businessHoursOnly: false
 # the job runs the failure flag is not set which caused the alert to then be resolved.  The time window should be set
 # to a duration longer than the duration of the job so that the alert doesn't clear (if failing) during run of the job.
 applicationCronJobStatusFailedWindowMinutes: 5
+
+
+# To monitor AWS OpenSearch domains, add the domain names and a display name in a map.
+# The key is the domain name from AWS, and the value is a friendly name for notifications.
+# openSearchAlertsDomainNames:
+#   cloud-platform-123abc: "My Application OpenSearch"
+#   cloud-platform-456def: "My Logging OpenSearch"
+
+# OpenSearch alert thresholds default to AWS recommendations:
+# https://docs.aws.amazon.com/opensearch-service/latest/developerguide/cloudwatch-alarms.html
+
+# Duration for which the cluster status must be RED before alerting (minutes).
+openSearchAlertsClusterStatusRedMinutes: 1
+
+# Duration for which the cluster status must be YELLOW before alerting (minutes).
+openSearchAlertsClusterStatusYellowMinutes: 5
+
+# Duration for which cluster index writes must be blocked before alerting (minutes).
+openSearchAlertsClusterIndexWritesBlockedMinutes: 5
+
+# Duration for which automated snapshot failures must persist before alerting (minutes).
+openSearchAlertsSnapshotFailureMinutes: 1
+
+# Minimum threshold for OpenSearch FreeStorageSpace (in GiB). AWS recommends setting this to 25% of your data node volume size.
+openSearchAlertsFreeStorageSpaceThresholdGB: 20
+openSearchAlertsFreeStorageSpaceThresholdMinutes: 1
+
+# Maximum threshold for OpenSearch data node CPUUtilization (percentage).
+openSearchAlertsCPUThreshold: 80
+openSearchAlertsCPUThresholdMinutes: 45
+
+# Maximum threshold for OpenSearch data node JVMMemoryPressure (percentage).
+openSearchAlertsJVMMemoryPressureThreshold: 95
+openSearchAlertsJVMMemoryPressureThresholdMinutes: 3


### PR DESCRIPTION
Creates alerts according to https://docs.aws.amazon.com/opensearch-service/latest/developerguide/cloudwatch-alarms.html (or at least the ones we can cover with the Prometheus metrics we have)

* Cluster status red / yellow
* Free storage space
* Blocked writes
* Automated snapshot failure
* High CPU utilisation
* High JVM memory pressure

Tested locally, here: https://mojdt.slack.com/archives/C033HPR0W91/p1750237464697489