### PR TITLE
FIX: set timezone on retry dlq job to match scheduled downtime job if…

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -8,4 +8,4 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: "3.12.3"
+version: "3.12.4"

--- a/charts/generic-service/templates/retry-dlq-cronjob.yaml
+++ b/charts/generic-service/templates/retry-dlq-cronjob.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   {{- if .Values.scheduledDowntime.enabled }}
   schedule: "{{ .Values.scheduledDowntime.retryDlqSchedule }}"
+  timeZone: {{ .Values.scheduledDowntime.timeZone }}
   {{- else }}
   schedule: "{{ .Values.retryDlqCronjob.retryDlqSchedule }}"
   {{- end }}


### PR DESCRIPTION
… scheduled downtime enabled

After setting the timezone on the scheduled downtime job in our namespace (hmpps-person-record-dev), we found that this job was running after the environment had already shut down

