### PR TITLE
Add support for HPA scaleup behavior

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -8,4 +8,4 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: "3.13.2"
+version: "3.14.0"

--- a/charts/generic-service/templates/hpa.yaml
+++ b/charts/generic-service/templates/hpa.yaml
@@ -29,4 +29,9 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
+  {{- if .Values.autoscaling.scaleUpStabilizationWindowSeconds }}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: {{ .Values.autoscaling.scaleUpStabilizationWindowSeconds }}
+  {{- end }}
 {{- end }}

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -159,6 +159,7 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+  # scaleUpStabilizationWindowSeconds: 180
 
 poddisruptionbudget:
   enabled: true


### PR DESCRIPTION
Adds support for configuring HPA scale-up behaviour by adjusting the stabilisation window. Reducing this allows for pods to spin up and become available faster under high load.