### PR TITLE
SDIT-3702: ✨ Add in cron prefix override

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -8,4 +8,4 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: "3.15.2"
+version: "3.16.0"

--- a/charts/generic-service/templates/_helpers.tpl
+++ b/charts/generic-service/templates/_helpers.tpl
@@ -25,6 +25,17 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Create a default cron prefix name. Using fullname is sometimes excessive so allow it to be shortened.
+*/}}
+{{- define "generic-service.cronPrefixName" -}}
+{{- if .Values.cronPrefixName }}
+{{- .Values.cronPrefixName }}
+{{- else }}
+{{- include "generic-service.fullname" . }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "generic-service.chart" -}}

--- a/charts/generic-service/templates/batch-cronjob.yaml
+++ b/charts/generic-service/templates/batch-cronjob.yaml
@@ -7,7 +7,7 @@ This template is a work in progress - please do not use yet!
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ printf "%s-%s" (include "generic-service.fullname" .) $job.name | trunc 52 | trimSuffix "-" | quote }}
+  name: {{ printf "%s-%s" (include "generic-service.cronPrefixName" .) $job.name | trunc 52 | trimSuffix "-" | quote }}
   labels:
     {{- include "generic-service.labels" . | nindent 4 }}
 spec:

--- a/charts/generic-service/templates/prison-postgres-database-restore.yaml
+++ b/charts/generic-service/templates/prison-postgres-database-restore.yaml
@@ -12,7 +12,7 @@ than the saved restore date then a new backup is created.
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ (.Values.postgresDatabaseRestore.jobName) | default (printf "%s-postgres-restore" (include "generic-service.fullname" .)) }}
+  name: {{ (.Values.postgresDatabaseRestore.jobName) | default (printf "%s-postgres-restore" (include "generic-service.cronPrefixName" .)) }}
   labels:
     {{- include "generic-service.labels" . | nindent 4 }}
 data:
@@ -24,7 +24,7 @@ data:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ (.Values.postgresDatabaseRestore.jobName) | default (printf "%s-postgres-restore" (include "generic-service.fullname" .)) }}
+  name: {{ (.Values.postgresDatabaseRestore.jobName) | default (printf "%s-postgres-restore" (include "generic-service.cronPrefixName" .)) }}
   labels:
     {{- include "generic-service.labels" . | nindent 4 }}
 spec:
@@ -46,7 +46,7 @@ spec:
               command:
                 - /bin/entrypoint.sh
               volumeMounts:
-                - name: {{ (.Values.postgresDatabaseRestore.jobName) | default (printf "%s-postgres-restore" (include "generic-service.fullname" .)) }}
+                - name: {{ (.Values.postgresDatabaseRestore.jobName) | default (printf "%s-postgres-restore" (include "generic-service.cronPrefixName" .)) }}
                   mountPath: /bin/entrypoint.sh
                   readOnly: true
                   subPath: entrypoint.sh
@@ -62,8 +62,8 @@ spec:
     {{- include "postgresRestore.envs" .Values | nindent 14 }}
           restartPolicy: "Never"
           volumes:
-            - name: {{ (.Values.postgresDatabaseRestore.jobName) | default (printf "%s-postgres-restore" (include "generic-service.fullname" .)) }}
+            - name: {{ (.Values.postgresDatabaseRestore.jobName) | default (printf "%s-postgres-restore" (include "generic-service.cronPrefixName" .)) }}
               configMap:
-                name: {{ (.Values.postgresDatabaseRestore.jobName) | default (printf "%s-postgres-restore" (include "generic-service.fullname" .)) }}
+                name: {{ (.Values.postgresDatabaseRestore.jobName) | default (printf "%s-postgres-restore" (include "generic-service.cronPrefixName" .)) }}
                 defaultMode: 0755
 {{- end }}

--- a/charts/generic-service/templates/retry-dlq-cronjob.yaml
+++ b/charts/generic-service/templates/retry-dlq-cronjob.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "generic-service.fullname" . | trunc 26 }}-retry-dlqs
+  name: {{ include "generic-service.cronPrefixName" . | trunc 26 }}-retry-dlqs
   labels:
     {{- include "generic-service.labels" . | nindent 4 }}
 spec:

--- a/charts/generic-service/templates/scheduled-downtime-cronjob.yaml
+++ b/charts/generic-service/templates/scheduled-downtime-cronjob.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "generic-service.fullname" . | trunc 43 }}-shutdown
+  name: {{ include "generic-service.cronPrefixName" . | trunc 43 }}-shutdown
   labels:
     {{- include "generic-service.labels" . | nindent 4 }}
 spec:
@@ -35,7 +35,7 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "generic-service.fullname" . | trunc 43 }}-startup
+  name: {{ include "generic-service.cronPrefixName" . | trunc 43 }}-startup
   labels:
     {{- include "generic-service.labels" . | nindent 4 }}
 spec:

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -15,6 +15,8 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+# override the default cron prefix of fullname. This is to prevent the cronjob names from getting too long / unreadable
+# cronPrefixName: "api"
 
 # Product ID as specified in the service catalogue
 # productId: "ID"


### PR DESCRIPTION
This PR is to allow override of the default full name for any cronjobs. This is to stop cronjobs from all starting with the same long name e.g.
```
NAME                                                   SCHEDULE                           TIMEZONE        SUSPEND   ACTIVE   LAST SCHEDULE   AGE
hmpps-prisoner-to-nomis-update-adjudication-recon      30 2 * * 1                         Europe/London   False     0        35h             232d
hmpps-prisoner-to-nomis-update-alert-recon             45 4 * * *                         Europe/London   False     0        8h              232d
hmpps-prisoner-to-nomis-update-allocations-recon       5 7 * * *                          Europe/London   False     0        6h39m           238d
hmpps-prisoner-to-nomis-update-appointment-recon       5 0 * * *                          Europe/London   False     0        13h             232d
hmpps-prisoner-to-nomis-update-attendances-recon       5 1 * * *                          Europe/London   False     0        12h             238d
hmpps-prisoner-to-nomis-update-casenote-active-recon   30 19 * * SUN,MON,TUE,WED,THU      Europe/London   False     0        18h             230d
hmpps-prisoner-to-nomis-update-casenote-full-recon     30 19 * * FRI                      Europe/London   False     0        3d18h           230d
hmpps-prisoner-to-nomis-update-con-per-prf-det-recon   30 3 * * *                         Europe/London   False     0        10h             238d
hmpps-prisoner-to-nomis-update-court-case-a-recon      10 3 * * *                         Europe/London   False     0        10h             201d
hmpps-prisoner-to-nomis-update-court-case-recon        0 19 * * SAT                       Europe/London   False     0        2d18h           201d
hmpps-prisoner-to-nomis-update-csip-recon              5 0 * * *                          Europe/London   False     0        13h             229d
hmpps-prisoner-to-nomis-update-incentives-recon        10 4 * * 1                         Europe/London   False     0        33h             229d
```
which then means we end up creating names like `con-per-prf-det-recon` to get round the 63 character limit