### PR TITLE
feat: add envoy-forward-proxy shared helm chart

### DIFF
--- a/charts/envoy-forward-proxy/.helmignore
+++ b/charts/envoy-forward-proxy/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+README.md
+.DS_Store
+.helmignore
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/envoy-forward-proxy/Chart.yaml
+++ b/charts/envoy-forward-proxy/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+appVersion: "1.0"
+description: A Helm chart for deploying an Envoy forward proxy for HTTPS CONNECT tunnelling
+name: envoy-forward-proxy
+version: 1.0.0

--- a/charts/envoy-forward-proxy/README.md
+++ b/charts/envoy-forward-proxy/README.md
@@ -1,0 +1,94 @@
+# Envoy Forward Proxy Helm Chart
+
+A Helm chart for deploying an [Envoy](https://www.envoyproxy.io/) forward proxy that uses HTTP CONNECT tunnelling to proxy HTTPS traffic. This is useful for proxying outbound HTTPS connections from applications that need to reach external services (e.g. Azure Application Insights, AWS SQS, HMPPS Auth).
+
+## Overview
+
+This chart deploys:
+
+- **Deployment**: An Envoy proxy configured as a forward HTTPS proxy using CONNECT tunnelling with dynamic forward proxy DNS resolution.
+- **Service**: A ClusterIP service exposing the proxy port within the namespace.
+- **ConfigMap**: The Envoy configuration including RBAC rules to restrict which upstream hosts are allowed.
+
+## Usage
+
+Add this chart as a dependency in your application's `Chart.yaml`:
+
+```yaml
+dependencies:
+  - name: envoy-forward-proxy
+    version: "1.0"
+    repository: https://ministryofjustice.github.io/hmpps-helm-charts
+```
+
+Then configure it in your `values.yaml`:
+
+```yaml
+envoy-forward-proxy:
+  enabled: true
+  # Additional hosts beyond the built-in defaults
+  allowedHosts:
+    exact:
+      - agent.azureserviceprofiler.net
+    suffixes:
+      - .example.com
+```
+
+The chart includes the following hosts by default (always included, additive with your configuration):
+- **Exact**: `sqs.eu-west-2.amazonaws.com`, `sts.eu-west-2.amazonaws.com`, `agent.azureserviceprofiler.net`
+- **Suffixes**: `.in.applicationinsights.azure.com`, `.livediagnostics.monitor.azure.com`, `.service.justice.gov.uk`
+
+You can also resolve hostnames dynamically from environment variable URLs:
+
+```yaml
+envoy-forward-proxy:
+  allowedHostEnvVars:
+    - MY_API_URL
+  envSource:
+    MY_API_URL: "https://my-api.example.com"
+```
+
+Then configure your application to use the proxy. The service name will be `<release>-envoy-forward-proxy` by default; use `fullnameOverride` to set a fixed name:
+
+```yaml
+envoy-forward-proxy:
+  fullnameOverride: envoy-https-proxy
+
+generic-service:
+  env:
+    HTTP_PROXY: "http://envoy-https-proxy:3128"
+    HTTPS_PROXY: "http://envoy-https-proxy:3128"
+    NO_PROXY: "localhost,127.0.0.1,envoy-https-proxy"
+```
+
+## Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `enabled` | Whether to deploy the envoy proxy | `true` |
+| `nameOverride` | Override the chart name | `""` |
+| `fullnameOverride` | Override the full resource name | `""` |
+| `replicas` | Number of proxy replicas | `2` |
+| `logLevel` | Envoy log level | `info` |
+| `image.repository` | Envoy image repository | `envoyproxy/envoy` |
+| `image.tag` | Envoy image tag | `v1.38-latest` |
+| `ports.proxy` | Proxy listener port | `3128` |
+| `ports.admin` | Admin interface port | `9901` |
+| `resources` | Container resource requests/limits | See `values.yaml` |
+| `allowedHosts.exact` | Additional exact hostnames to allow (on top of built-in defaults) | `[]` |
+| `allowedHosts.suffixes` | Additional hostname suffixes to allow (on top of built-in defaults) | `[]` |
+| `allowedHostEnvVars` | Env var names whose URL values should be allowed | `[]` |
+| `envSource` | Map of env var name to URL value for resolving `allowedHostEnvVars` | `{}` |
+| `dns.lookupFamily` | DNS lookup family | `V4_ONLY` |
+| `dns.hostTtl` | DNS host TTL | `300s` |
+| `connectTimeout` | Upstream connect timeout | `10s` |
+
+## How It Works
+
+The proxy uses Envoy's HTTP CONNECT tunnelling feature with a dynamic forward proxy cluster. When a client sends a CONNECT request, Envoy:
+
+1. Checks the `:authority` header against the RBAC allow list
+2. If allowed, resolves the upstream host via DNS
+3. Establishes a TCP tunnel to the upstream host on port 443
+
+This allows applications to make HTTPS requests through the proxy without the proxy needing to terminate TLS.

--- a/charts/envoy-forward-proxy/ci/test-values.yaml
+++ b/charts/envoy-forward-proxy/ci/test-values.yaml
@@ -1,0 +1,16 @@
+---
+fullnameOverride: envoy-https-proxy
+
+allowedHosts:
+  exact:
+    - custom-api.example.com
+  suffixes:
+    - .internal.example.com
+
+allowedHostEnvVars:
+  - HMPPS_AUTH_URL
+  - TOKEN_VERIFICATION_API_URL
+
+envSource:
+  HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
+  TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"

--- a/charts/envoy-forward-proxy/templates/_helpers.tpl
+++ b/charts/envoy-forward-proxy/templates/_helpers.tpl
@@ -1,0 +1,117 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "envoy-forward-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "envoy-forward-proxy.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "envoy-forward-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "envoy-forward-proxy.labels" -}}
+{{ include "envoy-forward-proxy.selectorLabels" . }}
+app.kubernetes.io/name: {{ include "envoy-forward-proxy.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: proxy
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "envoy-forward-proxy.chart" . }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "envoy-forward-proxy.selectorLabels" -}}
+app: {{ include "envoy-forward-proxy.fullname" . }}
+release: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Extract hostname from a URL string.
+Strips scheme, path, query string, fragment, and userinfo.
+*/}}
+{{- define "envoy-forward-proxy.hostFromUrl" -}}
+{{- $url := . | toString -}}
+{{- $withScheme := regexFind "https?://[^/?#]+" $url -}}
+{{- if $withScheme -}}
+{{- $host := trimPrefix "https://" (trimPrefix "http://" $withScheme) -}}
+{{- /* Strip userinfo (user:pass@) if present */ -}}
+{{- if contains "@" $host -}}
+{{- $host = regexFind "[^@]+$" $host -}}
+{{- end -}}
+{{- $host -}}
+{{- else -}}
+{{- $url -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate RBAC permissions list for the allowed hosts.
+Produces a YAML list of header matchers for the :authority header.
+Includes built-in defaults (AWS, Azure telemetry, service.justice.gov.uk) plus
+any additional hosts specified via allowedHosts and allowedHostEnvVars.
+*/}}
+{{- define "envoy-forward-proxy.rbacPermissions" -}}
+{{- $permissions := list -}}
+{{- /* Built-in default exact hosts */ -}}
+{{- $defaultExact := list "sqs.eu-west-2.amazonaws.com" "sts.eu-west-2.amazonaws.com" "agent.azureserviceprofiler.net" -}}
+{{- /* Built-in default suffix hosts */ -}}
+{{- $defaultSuffixes := list ".in.applicationinsights.azure.com" ".livediagnostics.monitor.azure.com" ".service.justice.gov.uk" -}}
+{{- range $defaultExact }}
+{{- $permissions = append $permissions (dict "header" (dict "name" ":authority" "string_match" (dict "exact" .))) -}}
+{{- $permissions = append $permissions (dict "header" (dict "name" ":authority" "string_match" (dict "exact" (printf "%s:443" .)))) -}}
+{{- end -}}
+{{- range $defaultSuffixes }}
+{{- $permissions = append $permissions (dict "header" (dict "name" ":authority" "string_match" (dict "suffix" .))) -}}
+{{- $permissions = append $permissions (dict "header" (dict "name" ":authority" "string_match" (dict "suffix" (printf "%s:443" .)))) -}}
+{{- end -}}
+{{- /* Additional exact hosts from values */ -}}
+{{- range .Values.allowedHosts.exact }}
+{{- if . }}
+{{- $permissions = append $permissions (dict "header" (dict "name" ":authority" "string_match" (dict "exact" .))) -}}
+{{- $permissions = append $permissions (dict "header" (dict "name" ":authority" "string_match" (dict "exact" (printf "%s:443" .)))) -}}
+{{- end -}}
+{{- end -}}
+{{- /* Additional suffix hosts from values */ -}}
+{{- range .Values.allowedHosts.suffixes }}
+{{- if . }}
+{{- $permissions = append $permissions (dict "header" (dict "name" ":authority" "string_match" (dict "suffix" .))) -}}
+{{- $permissions = append $permissions (dict "header" (dict "name" ":authority" "string_match" (dict "suffix" (printf "%s:443" .)))) -}}
+{{- end -}}
+{{- end -}}
+{{- /* Hosts resolved from environment variable URLs */ -}}
+{{- range $key := .Values.allowedHostEnvVars }}
+{{- $url := index $.Values.envSource $key -}}
+{{- if $url }}
+{{- $host := include "envoy-forward-proxy.hostFromUrl" $url -}}
+{{- $permissions = append $permissions (dict "header" (dict "name" ":authority" "string_match" (dict "exact" $host))) -}}
+{{- $permissions = append $permissions (dict "header" (dict "name" ":authority" "string_match" (dict "exact" (printf "%s:443" $host)))) -}}
+{{- end -}}
+{{- end -}}
+{{ toYaml $permissions }}
+{{- end -}}

--- a/charts/envoy-forward-proxy/templates/configmap.yaml
+++ b/charts/envoy-forward-proxy/templates/configmap.yaml
@@ -1,0 +1,106 @@
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "envoy-forward-proxy.fullname" . }}
+  labels:
+    {{- include "envoy-forward-proxy.labels" . | nindent 4 }}
+data:
+  envoy.yaml: |
+    admin:
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: {{ .Values.ports.admin }}
+
+    static_resources:
+      listeners:
+        - name: https_proxy_listener
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: {{ .Values.ports.proxy }}
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    stat_prefix: https_proxy
+                    codec_type: AUTO
+                    use_remote_address: true
+                    access_log:
+                      - name: envoy.access_loggers.stdout
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+                          log_format:
+                            json_format:
+                              start_time: "%START_TIME%"
+                              method: "%REQ(:METHOD)%"
+                              authority: "%REQ(:AUTHORITY)%"
+                              path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+                              protocol: "%PROTOCOL%"
+                              downstream_client_address: "%DOWNSTREAM_DIRECT_REMOTE_ADDRESS%"
+                              downstream_client_ip: "%DOWNSTREAM_DIRECT_REMOTE_ADDRESS_WITHOUT_PORT%"
+                              downstream_remote_address: "%DOWNSTREAM_REMOTE_ADDRESS%"
+                              downstream_remote_ip: "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"
+                              response_code: "%RESPONSE_CODE%"
+                              response_code_details: "%RESPONSE_CODE_DETAILS%"
+                              upstream_host: "%UPSTREAM_HOST%"
+                              upstream_cluster: "%UPSTREAM_CLUSTER%"
+                              upstream_service_time_ms: "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%"
+                              bytes_received: "%BYTES_RECEIVED%"
+                              bytes_sent: "%BYTES_SENT%"
+                              duration_ms: "%DURATION%"
+                              route_name: "%ROUTE_NAME%"
+                              requested_server_name: "%REQUESTED_SERVER_NAME%"
+                    route_config:
+                      name: https_proxy_route
+                      virtual_hosts:
+                        - name: approved-upstreams
+                          domains: ["*"]
+                          routes:
+                            - match:
+                                connect_matcher: {}
+                              route:
+                                cluster: dynamic_forward_proxy_cluster
+                                upgrade_configs:
+                                  - upgrade_type: CONNECT
+                                    connect_config: {}
+                    upgrade_configs:
+                      - upgrade_type: CONNECT
+                    http_filters:
+                      - name: envoy.filters.http.rbac
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+                          rules:
+                            action: ALLOW
+                            policies:
+                              approved-hosts:
+                                permissions:
+{{ include "envoy-forward-proxy.rbacPermissions" . | indent 34 }}
+                                principals:
+                                  - any: true
+                      - name: envoy.filters.http.dynamic_forward_proxy
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig
+                          dns_cache_config:
+                            name: dynamic_forward_proxy_cache_config
+                            dns_lookup_family: {{ .Values.dns.lookupFamily }}
+                            host_ttl: {{ .Values.dns.hostTtl }}
+                      - name: envoy.filters.http.router
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+      clusters:
+        - name: dynamic_forward_proxy_cluster
+          connect_timeout: {{ .Values.connectTimeout }}
+          lb_policy: CLUSTER_PROVIDED
+          cluster_type:
+            name: envoy.clusters.dynamic_forward_proxy
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+              dns_cache_config:
+                name: dynamic_forward_proxy_cache_config
+                dns_lookup_family: {{ .Values.dns.lookupFamily }}
+                host_ttl: {{ .Values.dns.hostTtl }}
+{{- end }}

--- a/charts/envoy-forward-proxy/templates/deployment.yaml
+++ b/charts/envoy-forward-proxy/templates/deployment.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "envoy-forward-proxy.fullname" . }}
+  labels:
+    {{- include "envoy-forward-proxy.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "envoy-forward-proxy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "envoy-forward-proxy.labels" . | nindent 8 }}
+      annotations:
+        checksum/envoy-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - {{ include "envoy-forward-proxy.fullname" . }}
+                topologyKey: kubernetes.io/hostname
+      containers:
+        - name: envoy
+          image: {{ printf "%s:%s" .Values.image.repository .Values.image.tag | quote }}
+          imagePullPolicy: Always
+          args:
+            - -c
+            - /etc/envoy/envoy.yaml
+            - --service-cluster
+            - {{ include "envoy-forward-proxy.fullname" . }}
+            - --log-level
+            - {{ .Values.logLevel }}
+          ports:
+            - name: proxy
+              containerPort: {{ .Values.ports.proxy }}
+            - name: admin
+              containerPort: {{ .Values.ports.admin }}
+          readinessProbe:
+            tcpSocket:
+              port: proxy
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: proxy
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: envoy-config
+              mountPath: /etc/envoy/envoy.yaml
+              subPath: envoy.yaml
+      volumes:
+        - name: envoy-config
+          configMap:
+            name: {{ include "envoy-forward-proxy.fullname" . }}
+{{- end }}

--- a/charts/envoy-forward-proxy/templates/service.yaml
+++ b/charts/envoy-forward-proxy/templates/service.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "envoy-forward-proxy.fullname" . }}
+  labels:
+    {{- include "envoy-forward-proxy.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "envoy-forward-proxy.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: https-proxy
+      port: {{ .Values.ports.proxy }}
+      targetPort: proxy
+{{- end }}

--- a/charts/envoy-forward-proxy/values.yaml
+++ b/charts/envoy-forward-proxy/values.yaml
@@ -1,0 +1,52 @@
+# Default values for envoy-forward-proxy.
+# This is a YAML-formatted file.
+
+# Whether to enable the envoy forward proxy deployment
+enabled: true
+
+replicas: 2
+
+logLevel: info
+
+image:
+  repository: envoyproxy/envoy
+  tag: v1.38-latest
+
+ports:
+  proxy: 3128
+  admin: 9901
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+# Additional allowed upstream hosts (added to built-in defaults).
+# Built-in defaults include:
+#   exact: sqs.eu-west-2.amazonaws.com, sts.eu-west-2.amazonaws.com, agent.azureserviceprofiler.net
+#   suffixes: .in.applicationinsights.azure.com, .livediagnostics.monitor.azure.com, .service.justice.gov.uk
+allowedHosts:
+  # Additional exact hostnames to allow
+  exact: []
+  # Additional hostname suffixes to allow (e.g. ".example.com" matches "foo.example.com")
+  suffixes: []
+
+# Environment variable names (from the parent chart's generic-service env block)
+# whose values are URLs. The hostname will be extracted and added to the allow list.
+allowedHostEnvVars: []
+
+# Reference to the parent chart's generic-service env block for resolving allowedHostEnvVars.
+# This should be set by the parent chart, e.g.:
+#   envoy-forward-proxy:
+#     envSource:
+#       HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
+envSource: {}
+
+dns:
+  lookupFamily: V4_ONLY
+  hostTtl: 300s
+
+connectTimeout: 10s


### PR DESCRIPTION
## Summary

Adds a new reusable Helm chart `envoy-forward-proxy` for deploying an Envoy forward proxy that uses HTTP CONNECT tunnelling to proxy outbound HTTPS traffic.

## Motivation

Deploying an Envoy proxy into hmpps namespaces creates a mechanism by which we can provide domain name based egress filtering using existing technologies available to us in Cloud Platform 2.0. This offers teams a pattern for network controls in their namespaces that gives significant strength in depth security posture compared to unfiltered, which can help reduce C2 communication, data exfiltration and lateral movement should a service be compromised.

See [ADR for more detail](https://dsdmoj.atlassian.net/wiki/spaces/NDSS/pages/6131056857/ADR+Proposal+-+Adopt+an+architectural+pattern+for+egress+filtering+by+allowlist+for+HMPPS+services+hosted+in+Cloud+Platform) 

## What's included

The chart deploys:
- **Deployment**: Envoy configured as a forward HTTPS proxy with CONNECT tunnelling and dynamic forward proxy DNS
- **Service**: ClusterIP service exposing the proxy port
- **ConfigMap**: Envoy configuration including RBAC rules to restrict which upstream hosts are allowed

### Key features
- Hosts can be allowed by exact match, suffix match, or by resolving hostnames from environment variable URLs (via `envSource`)
- `fullnameOverride` support for custom service naming (backward compatibility)
- Configurable DNS settings, connect timeout, resources, replicas, and log level
- Security hardened: runs as non-root, drops all capabilities, RuntimeDefault seccomp profile