### PR TITLE
fix: remove release label from envoy-forward-proxy selector

### DIFF
--- a/charts/envoy-forward-proxy/Chart.yaml
+++ b/charts/envoy-forward-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for deploying an Envoy forward proxy for HTTPS CONNECT tunnelling
 name: envoy-forward-proxy
-version: 1.0.0
+version: 1.0.1

--- a/charts/envoy-forward-proxy/templates/_helpers.tpl
+++ b/charts/envoy-forward-proxy/templates/_helpers.tpl
@@ -48,7 +48,6 @@ Selector labels
 */}}
 {{- define "envoy-forward-proxy.selectorLabels" -}}
 app: {{ include "envoy-forward-proxy.fullname" . }}
-release: {{ .Release.Name }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
## Problem

After deploying the `envoy-forward-proxy` chart, services cannot connect to the proxy. Connections to `envoy-https-proxy:3128` time out with `ETIMEDOUT`.

## Root Cause

The chart's `selectorLabels` included a `release` label in both the Deployment selector and Service selector. This causes failures when upgrading from the original parent-chart-managed envoy deployment:

1. **Immutable selector**: Kubernetes rejects updates to a Deployment's `spec.selector`. The original deployment selected only on `app: envoy-https-proxy` — adding `release` changes the selector, which the API server rejects.

2. **Service endpoint mismatch**: Even if the Service is updated with the new selector (requiring both `app` and `release`), existing pods don't have the `release` label, so the Service has no matching endpoints → connection timeouts.

## Fix

Remove `release` from `selectorLabels`. The selector now only uses `app`, matching the original deployment's selector. This is also semantically correct — the proxy is a shared namespace service that multiple apps connect to regardless of which Helm release deployed it.

Bumps chart version to 1.0.1.