### PR TITLE
Add support for HPA scaledown behavior

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -8,4 +8,4 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: "3.17.2"
+version: "3.18.0"

--- a/charts/generic-service/templates/deployment.yaml
+++ b/charts/generic-service/templates/deployment.yaml
@@ -26,6 +26,9 @@ spec:
       labels:
         {{- include "generic-service.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/generic-service/templates/hpa.yaml
+++ b/charts/generic-service/templates/hpa.yaml
@@ -29,9 +29,21 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
-  {{- if .Values.autoscaling.scaleUpStabilizationWindowSeconds }}
+  {{- if or .Values.autoscaling.scaleUpStabilizationWindowSeconds .Values.autoscaling.scaleDownStabilizationWindowSeconds .Values.autoscaling.scaleDownPolicies }}
   behavior:
+    {{- if .Values.autoscaling.scaleUpStabilizationWindowSeconds }}
     scaleUp:
       stabilizationWindowSeconds: {{ .Values.autoscaling.scaleUpStabilizationWindowSeconds }}
+    {{- end }}
+    {{- if or .Values.autoscaling.scaleDownStabilizationWindowSeconds .Values.autoscaling.scaleDownPolicies }}
+    scaleDown:
+      {{- if .Values.autoscaling.scaleDownStabilizationWindowSeconds }}
+      stabilizationWindowSeconds: {{ .Values.autoscaling.scaleDownStabilizationWindowSeconds }}
+      {{- end }}
+      {{- if .Values.autoscaling.scaleDownPolicies }}
+      policies:
+        {{- toYaml .Values.autoscaling.scaleDownPolicies | nindent 8 }}
+      {{- end }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -162,6 +162,11 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
   # scaleUpStabilizationWindowSeconds: 180
+  # scaleDownStabilizationWindowSeconds: 300
+  # scaleDownPolicies:
+  #   - type: Pods
+  #     value: 1
+  #     periodSeconds: 300
 
 poddisruptionbudget:
   enabled: true
@@ -199,6 +204,10 @@ readinessProbe:
 #   preStop:
 #     exec:
 #       command: ["/bin/sh", "-c", "echo Hello from the preStop handler"]
+
+# Grace period (seconds) k8s waits after preStop before SIGKILL. Must be >= preStop duration
+# plus time for the app to gracefully drain in-flight requests/connections. Defaults to 30 if unset.
+# terminationGracePeriodSeconds: 60
 
 strategy:
   type: RollingUpdate


### PR DESCRIPTION
These changes are an extension of [this](https://github.com/ministryofjustice/hmpps-helm-charts/pull/233) PR.

Adds support for configuring HPA scale-down behaviour (stabilisation window and rate-limiting policies), plus `terminationGracePeriodSeconds` on the Deployment.

By default, once the scale-down stabilisation window passes, Kubernetes allows up to 100% of pods to be removed within 15 seconds. For workloads with long-lived, non-portable in-memory connections (e.g. sticky-session WebSocket/SignalR-style workloads), this can disconnect many users simultaneously. This change lets consumers:

* Set a longer `scaleDownStabilizationWindowSeconds` to avoid reacting to short-lived dips in load.
* Set `scaleDownPolicies` to throttle how many pods are removed at once (e.g. one pod at a time, at most every 5 minutes), spreading disruption out instead of dropping several pods together.
* Set `terminationGracePeriodSeconds` so a `preStop` hook has enough time to run before `SIGKILL`, giving in-flight connections a chance to drain gracefully once a pod is pulled.

All additions are optional and backward compatible, omitting them preserves existing behaviour exactly.