### PR TITLE
feat!: remove alertSeverity config and document new alert routing flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ default: build
 
 ci_dir="charts/generic-prometheus-alerts/ci"
 objects=rules app ingress rds sns sqs opensearch
-apps=test-application test-business-hours
+apps=test-application test-business-hours test-prod
 group_names=$(foreach app,$(apps),$(addprefix $(app)-,$(objects)))
 
 test-application-%: compiled-test-application
@@ -12,6 +12,10 @@ test-application-%: compiled-test-application
 	yq eval 'select(.metadata.name == "$@") | .spec' $(ci_dir)/$<.yaml > $(ci_dir)/$@.yaml
 
 test-business-hours-%: compiled-test-business-hours
+	@echo Extracting $@
+	yq eval 'select(.metadata.name == "$@") | .spec' $(ci_dir)/$<.yaml > $(ci_dir)/$@.yaml
+
+test-prod-%: compiled-test-prod
 	@echo Extracting $@
 	yq eval 'select(.metadata.name == "$@") | .spec' $(ci_dir)/$<.yaml > $(ci_dir)/$@.yaml
 
@@ -29,3 +33,13 @@ clean:
 	rm -f $(ci_dir)/test-application/Chart.lock
 	rm -f $(ci_dir)/test-application/Chart.yaml
 	rm -rf $(ci_dir)/test-application/charts
+	rm -f $(ci_dir)/compiled-test-business-hours.yaml
+	rm -f $(ci_dir)/test-business-hours-*.yaml
+	rm -f $(ci_dir)/test-business-hours/Chart.lock
+	rm -f $(ci_dir)/test-business-hours/Chart.yaml
+	rm -rf $(ci_dir)/test-business-hours/charts
+	rm -f $(ci_dir)/compiled-test-prod.yaml
+	rm -f $(ci_dir)/test-prod-*.yaml
+	rm -f $(ci_dir)/test-prod/Chart.lock
+	rm -f $(ci_dir)/test-prod/Chart.yaml
+	rm -rf $(ci_dir)/test-prod/charts

--- a/charts/generic-prometheus-alerts/Chart.yaml
+++ b/charts/generic-prometheus-alerts/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.17.1
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/generic-prometheus-alerts/README.md
+++ b/charts/generic-prometheus-alerts/README.md
@@ -2,9 +2,38 @@
 
 This chart creates a standard set of prometheus alerts for a given application.
 
-You must provide it with a value for `targetApplication`, this is used within the queries to filter results.
+## Breaking change (major upgrade)
 
-You must also provide a value for `alertSeverity`, this enables integration with slack and being able to receive alerts via slack. This value determines how alerts get routed to a slack channel. This is a process defined by the CloudPlatform team, see [Cloud Platform User Guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts)
+From `2.0.0` onwards, `alertSeverity` is deprecated and must be removed from consumer values files.
+
+If `alertSeverity` is still set, chart rendering will fail with a deprecation message.
+
+### Required team actions
+
+- Remove `alertSeverity` from your chart values.
+- Ensure these repository variables are set with appropriate values, for example the Slack channel where alerts are sent (do not include a preceding `#`; a Slack ID is also valid, as well as the Slack channel name):
+  - `PROD_ALERTS_SLACK_CHANNEL`
+  - `PROD_RELEASES_SLACK_CHANNEL`
+
+Alert routing depends on repository variables. You must ensure these are set with appropriate values, for example the Slack channel where alerts are sent (do not include a preceding `#`; a Slack ID is also valid, as well as the Slack channel name):
+
+- `PROD_ALERTS_SLACK_CHANNEL`
+- `PROD_RELEASES_SLACK_CHANNEL`
+
+Alert delivery and forwarding now works as follows:
+
+- Alerts are first delivered to centrally managed Slack channels:
+  - `#hmpps-prometheus-alerts-prod`
+  - `#hmpps-prometheus-alerts-nonprod`
+- Alerts are then forwarded to the relevant team alerting channel by the hmpps-slack-relay-bot.
+- The relay bot determines the correct app/environment/channel mapping from Developer Portal (Service Catalogue) data.
+
+For context, this chart still uses an alert `severity` label to split prod/non-prod routing:
+
+- `prod` or `production` -> `hmpps_alerts_prod`
+- any other value (or unset) -> `hmpps_alerts_nonprod`
+
+This severity-based routing is MoJ-specific behavior which enables routing alert messages based on an existing label.
 
 ## Quick start
 
@@ -13,7 +42,7 @@ Add this to your project as a dependency chart, in your `Chart.yaml`:
 ```yaml
 dependencies:
   - name: generic-prometheus-alerts
-    version: 0.1.3
+    version: 2.0.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
 ```
 
@@ -22,11 +51,12 @@ in your applications helm chart `values.yaml` add:
 ```yaml
 generic-prometheus-alerts:
   targetApplication: YOUR-APP-NAME-HERE
-  alertSeverity: AS-GIVEN-BY-CLOUD-PLATFORM
 ```
+
+You must provide a value for `targetApplication`. This is used within alert queries to filter results.
 
 Also set any other non-default values or overrides. See available options here:
 
 [generic-prometheus-alerts/values.yaml](./values.yaml)
 
-If you wish to create a new `alertSeverity` group to change which Slack channels alerts are sent to you can follow the [Cloud Platform User Guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#overview)
+`global.environment` is set by the shared GitHub Actions deploy job and controls production vs non-production routing.

--- a/charts/generic-prometheus-alerts/README.md
+++ b/charts/generic-prometheus-alerts/README.md
@@ -13,12 +13,12 @@ If `alertSeverity` is still set, chart rendering will fail with a deprecation me
 - Remove `alertSeverity` from your chart values.
 - Ensure these repository variables are set with appropriate values, for example the Slack channel where alerts are sent (do not include a preceding `#`; a Slack ID is also valid, as well as the Slack channel name):
   - `PROD_ALERTS_SLACK_CHANNEL`
-  - `PROD_RELEASES_SLACK_CHANNEL`
+  - `NONPROD_ALERTS_SLACK_CHANNEL`
 
 Alert routing depends on repository variables. You must ensure these are set with appropriate values, for example the Slack channel where alerts are sent (do not include a preceding `#`; a Slack ID is also valid, as well as the Slack channel name):
 
 - `PROD_ALERTS_SLACK_CHANNEL`
-- `PROD_RELEASES_SLACK_CHANNEL`
+- `NONPROD_ALERTS_SLACK_CHANNEL`
 
 Alert delivery and forwarding now works as follows:
 

--- a/charts/generic-prometheus-alerts/ci/test-application/values.yaml
+++ b/charts/generic-prometheus-alerts/ci/test-application/values.yaml
@@ -2,7 +2,6 @@
 generic-prometheus-alerts:
   targetApplication: "test-application"
   runbookUrl: "https://runbook.com/"
-  alertSeverity: "alert-severity-tag"
   rdsAlertsDatabases:
     cloud-platform-uuid: "test rds"
   sqsAlertsQueueNames:

--- a/charts/generic-prometheus-alerts/ci/test-prod/Chart.tpl.yaml
+++ b/charts/generic-prometheus-alerts/ci/test-prod/Chart.tpl.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: test-prod
+version: 0.2.0
+
+dependencies:
+  - name: generic-prometheus-alerts
+    version: $CHART_VERSION
+    repository: file://../../

--- a/charts/generic-prometheus-alerts/ci/test-prod/values.yaml
+++ b/charts/generic-prometheus-alerts/ci/test-prod/values.yaml
@@ -1,6 +1,6 @@
 ---
 generic-prometheus-alerts:
-  targetApplication: "test-business-hours"
+  targetApplication: "test-prod"
   runbookUrl: "https://runbook.com/"
   rdsAlertsDatabases:
     cloud-platform-uuid: "test rds"
@@ -8,7 +8,11 @@ generic-prometheus-alerts:
     - "queue-name"
   openSearchAlertsDomainNames:
     cloud-platform-uuid: "test-domain"
-  businessHoursOnly: true
+  businessHoursOnly: false
+  ingress2xxEnabled: true
   sqsAlertsInactiveThreshold: 20
   sqsInactiveAlertQueueNames:
     - "queue-name"
+
+global:
+  environment: prod

--- a/charts/generic-prometheus-alerts/ci/test-values.yaml
+++ b/charts/generic-prometheus-alerts/ci/test-values.yaml
@@ -1,3 +1,2 @@
 ---
 targetApplication: "test-application-name"
-alertSeverity: "alert-severity-tag"

--- a/charts/generic-prometheus-alerts/ci/tests/application-alerts-tests.yaml
+++ b/charts/generic-prometheus-alerts/ci/tests/application-alerts-tests.yaml
@@ -61,7 +61,7 @@ tests:
               job_name: test-application-cronjob-2
               namespace: test-application-dev
               owner_name: test-application-cronjob
-              severity: alert-severity-tag
+              severity: hmpps_alerts_nonprod
               application: test-application
               businessUnit: hmpps
               environment: none
@@ -167,7 +167,7 @@ tests:
               job_name: test-application-cronjob-1
               namespace: test-application-dev
               owner_name: test-application-cronjob
-              severity: alert-severity-tag
+              severity: hmpps_alerts_nonprod
               application: test-application
               businessUnit: hmpps
               environment: none

--- a/charts/generic-prometheus-alerts/ci/tests/aws-elasticache-alerts-tests.yaml
+++ b/charts/generic-prometheus-alerts/ci/tests/aws-elasticache-alerts-tests.yaml
@@ -18,7 +18,7 @@ tests:
         exp_alerts:
           - exp_labels:
               dbinstance_identifier: cloud-platform-uuid
-              severity: alert-severity-tag
+              severity: hmpps_alerts_nonprod
               application: test-application
               businessUnit: hmpps
               environment: none

--- a/charts/generic-prometheus-alerts/ci/tests/aws-opensearch-alerts-tests.yaml
+++ b/charts/generic-prometheus-alerts/ci/tests/aws-opensearch-alerts-tests.yaml
@@ -22,7 +22,7 @@ tests:
               businessUnit: hmpps
               domain_name: cloud-platform-uuid
               environment: none
-              severity: alert-severity-tag
+              severity: hmpps_alerts_nonprod
             exp_annotations:
               summary: OpenSearch cluster status is red
               message: test-domain in test-application-dev - Cluster status is red. At least one primary shard and its replicas are not allocated to a node.
@@ -45,7 +45,7 @@ tests:
               businessUnit: hmpps
               domain_name: cloud-platform-uuid
               environment: none
-              severity: alert-severity-tag
+              severity: hmpps_alerts_nonprod
             exp_annotations:
               summary: OpenSearch cluster status is yellow
               message: test-domain in test-application-dev - Cluster status is yellow. At least one replica shard is not allocated to a node.
@@ -69,7 +69,7 @@ tests:
               domain_name: cloud-platform-uuid
               environment: none
               node_id: node1
-              severity: alert-severity-tag
+              severity: hmpps_alerts_nonprod
             exp_annotations:
               summary: OpenSearch free storage space is low
               message: test-domain in test-application-dev - A node in your cluster has less than 20 GiB of free storage space.
@@ -93,7 +93,7 @@ tests:
               domain_name: cloud-platform-uuid
               environment: none
               node_id: node1
-              severity: alert-severity-tag
+              severity: hmpps_alerts_nonprod
             exp_annotations:
               summary: OpenSearch automated snapshot failed
               message: test-domain in test-application-dev - An automated snapshot failed. This failure is often the result of a red cluster health status.
@@ -117,7 +117,7 @@ tests:
               domain_name: cloud-platform-uuid
               environment: none
               node_id: node1
-              severity: alert-severity-tag
+              severity: hmpps_alerts_nonprod
             exp_annotations:
               summary: OpenSearch JVM memory pressure is too high
               message: test-domain in test-application-dev - High JVM memory pressure. The cluster could encounter out of memory errors if usage increases. Consider scaling vertically.
@@ -143,7 +143,7 @@ tests:
               domain_name: cloud-platform-uuid
               environment: none
               node_id: node1
-              severity: alert-severity-tag
+              severity: hmpps_alerts_nonprod
             exp_annotations:
               summary: OpenSearch IOPS is too high
               message: test-domain in test-application-dev - High IOPS. Consistent high IOPS can result in performance degradation and lead to node failures.

--- a/charts/generic-prometheus-alerts/ci/tests/aws-rds-alerts-connection-tests.yaml
+++ b/charts/generic-prometheus-alerts/ci/tests/aws-rds-alerts-connection-tests.yaml
@@ -18,7 +18,7 @@ tests:
         exp_alerts:
           - exp_labels:
               dbinstance_identifier: cloud-platform-uuid
-              severity: alert-severity-tag
+              severity: hmpps_alerts_nonprod
               application: test-application
               businessUnit: hmpps
               environment: none

--- a/charts/generic-prometheus-alerts/ci/tests/aws-rds-alerts-cpu-tests.yaml
+++ b/charts/generic-prometheus-alerts/ci/tests/aws-rds-alerts-cpu-tests.yaml
@@ -18,7 +18,7 @@ tests:
         exp_alerts:
           - exp_labels:
               dbinstance_identifier: cloud-platform-uuid
-              severity: alert-severity-tag
+              severity: hmpps_alerts_nonprod
               application: test-application
               businessUnit: hmpps
               environment: none

--- a/charts/generic-prometheus-alerts/ci/tests/aws-sqs-alerts-tests.yaml
+++ b/charts/generic-prometheus-alerts/ci/tests/aws-sqs-alerts-tests.yaml
@@ -22,7 +22,7 @@ tests:
               businessUnit: hmpps
               queue_name: queue-name
               environment: none
-              severity: alert-severity-tag
+              severity: hmpps_alerts_nonprod
             exp_annotations:
               summary: SQS no messages received alert
               message: SQS - queue-name - has not received any messages in the last 20 mins.

--- a/charts/generic-prometheus-alerts/ci/tests/environment-prod-severity-tests.yaml
+++ b/charts/generic-prometheus-alerts/ci/tests/environment-prod-severity-tests.yaml
@@ -1,0 +1,46 @@
+---
+rule_files:
+  - ../test-prod-app.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 5m
+    input_series:
+      - series: 'kube_job_status_failed{job="kube-state-metrics", job_name="test-prod-cronjob-1", namespace="test-prod-dev", reason="BackoffLimitExceeded"}'
+        values: '1+0x12'
+      - series: 'kube_job_status_start_time{job="kube-state-metrics", job_name="test-prod-cronjob-1", namespace="test-prod-dev"}'
+        values: '0+0x12'
+      - series: 'kube_job_owner{job="kube-state-metrics", job_name="test-prod-cronjob-1", namespace="test-prod-dev", owner_kind="CronJob", owner_name="test-prod-cronjob"}'
+        values: '1+1x12'
+      - series: 'kube_cronjob_spec_suspend{cronjob="test-prod-cronjob", job="kube-state-metrics", namespace="test-prod-dev"}'
+        values: '0+0x12'
+
+      - series: 'kube_job_status_failed{job="kube-state-metrics", job_name="test-prod-cronjob-2", namespace="test-prod-dev", reason="DeadLineExceeded"}'
+        values: '1+0x12'
+      - series: 'kube_job_status_start_time{job="kube-state-metrics", job_name="test-prod-cronjob-2", namespace="test-prod-dev"}'
+        values: '900+0x12'
+      - series: 'kube_job_owner{job="kube-state-metrics", job_name="test-prod-cronjob-2", namespace="test-prod-dev", owner_kind="CronJob", owner_name="test-prod-cronjob"}'
+        values: '1+1x12'
+      - series: 'kube_cronjob_spec_suspend{cronjob="test-prod-cronjob", job="kube-state-metrics", namespace="test-prod-dev"}'
+        values: '0+0x12'
+
+    alert_rule_test:
+      - eval_time: 35m
+        alertname: CronJobStatusFailed
+        exp_alerts:
+          - exp_labels:
+              cronjob: test-prod-cronjob
+              job: test-prod-cronjob-2
+              job_name: test-prod-cronjob-2
+              namespace: test-prod-dev
+              owner_name: test-prod-cronjob
+              severity: hmpps_alerts_prod
+              application: test-prod
+              businessUnit: hmpps
+              environment: prod
+            exp_annotations:
+              message: CronJob test-prod-dev/test-prod-cronjob is failing.
+              runbook_url: https://runbook.com/application-cronjob-failed
+              dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/golden-signals/golden-signals?orgId=1&var-namespace=test-prod-dev&var-service=test-prod"
+              summary: CronJob is failing.

--- a/charts/generic-prometheus-alerts/ci/tests/ingress-alerts-tests-hourly.yaml
+++ b/charts/generic-prometheus-alerts/ci/tests/ingress-alerts-tests-hourly.yaml
@@ -38,7 +38,7 @@ tests:
               alertname: 2xxResponses
               exported_namespace: test-application-dev
               ingress: test-application-v1-2
-              severity: alert-severity-tag
+              severity: hmpps_alerts_nonprod
               application: test-application
               businessUnit: hmpps
               environment: none

--- a/charts/generic-prometheus-alerts/ci/tests/ingress-alerts-tests.yaml
+++ b/charts/generic-prometheus-alerts/ci/tests/ingress-alerts-tests.yaml
@@ -36,7 +36,7 @@ tests:
               alertname: 5xxErrorResponses
               exported_namespace: test-application-dev
               ingress: test-application-v1-2
-              severity: alert-severity-tag
+              severity: hmpps_alerts_nonprod
               application: test-application
               businessUnit: hmpps
               environment: none
@@ -82,7 +82,7 @@ tests:
               alertname: 5xxErrorResponsesOnHealthEndpoint
               exported_namespace: test-application-dev
               ingress: test-application-v1-2
-              severity: alert-severity-tag
+              severity: hmpps_alerts_nonprod
               application: test-application
               businessUnit: hmpps
               environment: none
@@ -165,7 +165,7 @@ tests:
               alertname: RatelimitBlocking
               exported_namespace: test-application-dev
               ingress: test-application-v1-2
-              severity: alert-severity-tag
+              severity: hmpps_alerts_nonprod
               application: test-application
               businessUnit: hmpps
               environment: none
@@ -226,7 +226,7 @@ tests:
               alertname: ModSecurityBlocking
               exported_namespace: test-application-dev
               ingress: test-application-v1-2
-              severity: alert-severity-tag
+              severity: hmpps_alerts_nonprod
               application: test-application
               businessUnit: hmpps
               environment: none

--- a/charts/generic-prometheus-alerts/templates/_helpers.tpl
+++ b/charts/generic-prometheus-alerts/templates/_helpers.tpl
@@ -58,8 +58,15 @@ Prometheus Rule labels
 {{- define "generic-prometheus-alerts.ruleLabels" -}}
 {{- $targetApplication := required "A value for targetApplication must be set" .Values.targetApplication }}
 {{- $businessUnit := required "A value for businessUnit must be set" .Values.businessUnit }}
-{{- $alertSeverity := required "A value for alertSeverity must be set" .Values.alertSeverity }}
+{{- if .Values.alertSeverity -}}
+{{- fail "alertSeverity is deprecated for generic-prometheus-alerts and must be removed. Please see release notes for this major version upgrade." -}}
+{{- end -}}
 {{- $environment := default "none" (.Values.global).environment -}}
+{{- $environmentLower := lower $environment -}}
+{{- $alertSeverity := "hmpps_alerts_nonprod" -}}
+{{- if or (eq $environmentLower "prod") (eq $environmentLower "production") -}}
+{{- $alertSeverity = "hmpps_alerts_prod" -}}
+{{- end -}}
 {{- if .Values.additionalRuleLabels -}}
 {{ toYaml .Values.additionalRuleLabels }}
 {{ end -}}

--- a/charts/generic-prometheus-alerts/values.schema.json
+++ b/charts/generic-prometheus-alerts/values.schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "alertSeverity": false
+  }
+}

--- a/charts/generic-prometheus-alerts/values.yaml
+++ b/charts/generic-prometheus-alerts/values.yaml
@@ -9,9 +9,6 @@ targetApplication: ""
 # To disable inclusion of ingress alerts, set to false, defaults true
 ingressAlertsEnabled: true
 
-# The alert severity label is used within Alert Manager and determines which slack channel alerts are sent to.
-alertSeverity: ""
-
 # These values used in the rule labels, which enables better filtering of alerts in alertmanager.  Global helm values used by these labels are passed in at helm upgrade/install time.
 businessUnit: hmpps
 # global:


### PR DESCRIPTION
This covers the breaking change to derive alert severity from global.environment, the updated README guidance for central Slack routing and relay bot forwarding, and the new deprecation enforcement for alertSeverity.
