### PR TITLE
feat: Additional scale targets in downtime cronjob

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -8,4 +8,4 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: "3.17.4"
+version: "3.17.5"

--- a/charts/generic-service/README.md
+++ b/charts/generic-service/README.md
@@ -275,6 +275,9 @@ To change this schedule, update the `startupOverride` and `shutdown` values
 
 You can have the schedule respect British Summer Time by setting `timeZone: Europe/London`
 
+By default, only the main deployment managed by this chart is scaled.
+You can also scale additional workloads (for example events processor or jobs processor deployments)
+using `scheduledDowntime.additionalScaleTargets`.
 
 
 ```yaml
@@ -286,6 +289,32 @@ scheduledDowntime:
   timeZone: Etc/UTC
   serviceAccountName: scheduled-downtime-serviceaccount # This must match the service account name in the Terraform module
 ```
+
+#### Scaling additional workloads during downtime
+
+`scheduledDowntime.additionalScaleTargets` is optional and defaults to an empty list.
+
+Only Kubernetes `Deployment` targets are supported by `additionalScaleTargets`.
+
+For each target:
+
+- `name` is required
+- `startupReplicas` is required
+
+Each additional target is always scaled to `0` during shutdown.
+
+```yaml
+---
+scheduledDowntime:
+  enabled: true
+  additionalScaleTargets:
+    - name: my-service-events-processor
+      startupReplicas: 1
+    - name: my-service-jobs-processor
+      startupReplicas: 2
+```
+
+If you use additional targets, ensure the scheduled downtime service account has scale permissions for those workloads too.
 
 ### Retrying messages on a dead letter queue
 

--- a/charts/generic-service/ci/test-values.yaml
+++ b/charts/generic-service/ci/test-values.yaml
@@ -22,6 +22,11 @@ allowlist_groups:
 
 scheduledDowntime:
   enabled: true
+  additionalScaleTargets:
+    - name: example-events-processor
+      startupReplicas: 1
+    - name: example-jobs-processor
+      startupReplicas: 2
 
 retryDlqCronjob:
   enabled: true

--- a/charts/generic-service/templates/scheduled-downtime-cronjob.yaml
+++ b/charts/generic-service/templates/scheduled-downtime-cronjob.yaml
@@ -1,6 +1,8 @@
 {{- if .Values.scheduledDowntime.enabled -}}
-{{- $hashServiceName  := regexReplaceAll "[^0-9]+" ((include "generic-service.fullname" .)  | sha256sum)  ""  | trunc 3 -}}
+{{- $fullName := include "generic-service.fullname" . -}}
+{{- $hashServiceName  := regexReplaceAll "[^0-9]+" ($fullName | sha256sum)  ""  | trunc 3 -}}
 {{- $randomMinute := printf "%d" (mod (atoi $hashServiceName) 60) -}}
+{{- $additionalScaleTargets := .Values.scheduledDowntime.additionalScaleTargets | default (list) -}}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -24,12 +26,15 @@ spec:
           containers:
             - name: hmpps-devops-tools
               image: "{{ .Values.scheduledDowntime.image }}:{{ .Values.scheduledDowntime.tag }}"
+              command:
+                - /bin/sh
+                - -ec
               args:
-                - kubectl
-                - scale
-                - deploy
-                - {{ include "generic-service.fullname" . }}
-                - --replicas=0
+                - |
+                  kubectl scale deployment/{{ $fullName }} --replicas=0
+                  {{- range $index, $target := $additionalScaleTargets }}
+                  kubectl scale deployment/{{ required (printf "scheduledDowntime.additionalScaleTargets[%d].name is required" $index) $target.name }} --replicas=0
+                  {{- end }}
               securityContext:
                 {{- toYaml .Values.scheduledDowntime.securityContext | nindent 16 }}
           restartPolicy: OnFailure
@@ -58,12 +63,15 @@ spec:
           containers:
             - name: hmpps-devops-tools
               image: ghcr.io/ministryofjustice/hmpps-devops-tools:latest
+              command:
+                - /bin/sh
+                - -ec
               args:
-                - kubectl
-                - scale
-                - deploy
-                - {{ include "generic-service.fullname" . }}
-                - --replicas={{ .Values.replicaCount }}
+                - |
+                  kubectl scale deployment/{{ $fullName }} --replicas={{ .Values.replicaCount }}
+                  {{- range $index, $target := $additionalScaleTargets }}
+                  kubectl scale deployment/{{ required (printf "scheduledDowntime.additionalScaleTargets[%d].name is required" $index) $target.name }} --replicas={{ required (printf "scheduledDowntime.additionalScaleTargets[%d].startupReplicas is required" $index) $target.startupReplicas }}
+                  {{- end }}
               securityContext:
                 {{- toYaml .Values.securityContext | nindent 16 }}
           restartPolicy: OnFailure

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -266,6 +266,15 @@ scheduledDowntime:
   # every 10 minutes between 7am and 8.50pm UTC Monday-Friday
   # the shutdown time is varied on deployment so this is deliberately much earlier
   retryDlqSchedule: "*/10 7-20 * * 1-5"
+  # Optional list of extra resources to scale down/up alongside the main deployment.
+  # On shutdown each target is always scaled to 0 replicas.
+  # On startup each target scales to its required startupReplicas value.
+  # additionalScaleTargets:
+  #   - name: my-service-events-processor
+  #     startupReplicas: 1
+  #   - name: my-service-jobs-processor
+  #     startupReplicas: 2
+  additionalScaleTargets: []
   image: *devopsToolsImage
   tag: *devopsToolsTag
   securityContext: *securityContext


### PR DESCRIPTION
Allow users to scale additional deployments (e.g. events processor, jobs processor) alongside the main deployment during scheduled downtime via optional `scheduledDowntime.additionalScaleTargets` configuration.

Update docs with examples and validation requirements.

Bump chart version to 3.17.5 (backward compatible).