### PR TITLE
feat: add git labels to helm chart

### DIFF
--- a/charts/generic-service/templates/_helpers.tpl
+++ b/charts/generic-service/templates/_helpers.tpl
@@ -58,6 +58,15 @@ hmpps.justice.gov.uk/product-id: {{ .Values.productId }}
 {{- end }}
 
 {{/*
+Git metadata annotations, identifying the source repo/commit/ref that deployed this release.
+*/}}
+{{- define "generic-service.gitAnnotations" -}}
+hmpps.justice.gov.uk/repo-url: {{ .Values.gitRepoUrl | default "unknown" | quote }}
+hmpps.justice.gov.uk/commit-sha: {{ .Values.gitCommitSha | default "unknown" | quote }}
+hmpps.justice.gov.uk/ref-name: {{ .Values.gitRefName | default "unknown" | quote }}
+{{- end }}
+
+{{/*
 Selector labels
 */}}
 {{- define "generic-service.selectorLabels" -}}

--- a/charts/generic-service/templates/batch-cronjob.yaml
+++ b/charts/generic-service/templates/batch-cronjob.yaml
@@ -7,6 +7,8 @@ metadata:
   name: {{ printf "%s-%s" (include "generic-service.cronPrefixName" .) $job.name | trunc 52 | trimSuffix "-" | quote }}
   labels:
     {{- include "generic-service.labels" . | nindent 4 }}
+  annotations:
+    {{- include "generic-service.gitAnnotations" . | nindent 4 }}
 spec:
   suspend:  {{ $job.suspend | default false }}
   schedule: {{ $job.schedule | quote }}

--- a/charts/generic-service/templates/deployment.yaml
+++ b/charts/generic-service/templates/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "generic-service.fullname" . }}
   labels:
     {{- include "generic-service.labels" . | nindent 4 }}
+  annotations:
+    {{- include "generic-service.gitAnnotations" . | nindent 4 }}
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -19,10 +21,11 @@ spec:
       {{- include "generic-service.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
       annotations:
+        {{- include "generic-service.gitAnnotations" . | nindent 8 }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+        {{- end }}
       labels:
         {{- include "generic-service.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/generic-service/templates/hpa.yaml
+++ b/charts/generic-service/templates/hpa.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "generic-service.fullname" . }}
   labels:
     {{- include "generic-service.labels" . | nindent 4 }}
+  annotations:
+    {{- include "generic-service.gitAnnotations" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/generic-service/templates/ingress.yaml
+++ b/charts/generic-service/templates/ingress.yaml
@@ -12,6 +12,7 @@ metadata:
   labels:
     {{- include "generic-service.labels" . | nindent 4 }}
   annotations:
+    {{- include "generic-service.gitAnnotations" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/generic-service/templates/networkpolicy.yaml
+++ b/charts/generic-service/templates/networkpolicy.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "generic-service.fullname" . }}-monitoring
   labels:
     {{- include "generic-service.labels" . | nindent 4 }}
+  annotations:
+    {{- include "generic-service.gitAnnotations" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/generic-service/templates/pdb.yaml
+++ b/charts/generic-service/templates/pdb.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "generic-service.fullname" . }}
   labels:
     {{- include "generic-service.labels" . | nindent 4 }}
+  annotations:
+    {{- include "generic-service.gitAnnotations" . | nindent 4 }}
 spec:
   minAvailable: {{ .Values.poddisruptionbudget.minAvailable }}
   selector:

--- a/charts/generic-service/templates/prison-postgres-database-backup.yaml
+++ b/charts/generic-service/templates/prison-postgres-database-backup.yaml
@@ -19,6 +19,8 @@ metadata:
   name: {{ (.Values.postgresDatabaseRestore.backupJobName) | default (printf "%s-postgres-backup" (include "generic-service.fullname" .)) }}
   labels:
     {{- include "generic-service.labels" . | nindent 4 }}
+  annotations:
+    {{- include "generic-service.gitAnnotations" . | nindent 4 }}
 data:
   entrypoint.sh: |-
     #!/bin/bash
@@ -34,6 +36,8 @@ metadata:
   name: {{ (.Values.postgresDatabaseRestore.backupJobName) | default (printf "%s-postgres-backup" (include "generic-service.fullname" .)) }}
   labels:
     {{- include "generic-service.labels" . | nindent 4 }}
+  annotations:
+    {{- include "generic-service.gitAnnotations" . | nindent 4 }}
 spec:
   schedule: "30 4 * * SUN" # this must be the same time as the Sunday Oracle NOMIS backup
   concurrencyPolicy: "Forbid"

--- a/charts/generic-service/templates/prison-postgres-database-restore.yaml
+++ b/charts/generic-service/templates/prison-postgres-database-restore.yaml
@@ -17,6 +17,8 @@ metadata:
   name: {{ (.Values.postgresDatabaseRestore.jobName) | default (printf "%s-postgres-restore" (include "generic-service.cronPrefixName" .)) }}
   labels:
     {{- include "generic-service.labels" . | nindent 4 }}
+  annotations:
+    {{- include "generic-service.gitAnnotations" . | nindent 4 }}
 data:
   entrypoint.sh: |-
     #!/bin/bash
@@ -32,6 +34,8 @@ metadata:
   name: {{ (.Values.postgresDatabaseRestore.jobName) | default (printf "%s-postgres-restore" (include "generic-service.cronPrefixName" .)) }}
   labels:
     {{- include "generic-service.labels" . | nindent 4 }}
+  annotations:
+    {{- include "generic-service.gitAnnotations" . | nindent 4 }}
 spec:
   schedule: {{ .Values.postgresDatabaseRestore.schedule | default (print $randomMinute "/30 6-21 * * 0-5") }}
   concurrencyPolicy: "Forbid"

--- a/charts/generic-service/templates/retry-dlq-cronjob.yaml
+++ b/charts/generic-service/templates/retry-dlq-cronjob.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "generic-service.cronPrefixName" . | trunc 26 }}-retry-dlqs
   labels:
     {{- include "generic-service.labels" . | nindent 4 }}
+  annotations:
+    {{- include "generic-service.gitAnnotations" . | nindent 4 }}
 spec:
   {{- if .Values.scheduledDowntime.enabled }}
   schedule: "{{ .Values.scheduledDowntime.retryDlqSchedule }}"

--- a/charts/generic-service/templates/scheduled-downtime-cronjob.yaml
+++ b/charts/generic-service/templates/scheduled-downtime-cronjob.yaml
@@ -9,6 +9,8 @@ metadata:
   name: {{ include "generic-service.cronPrefixName" . | trunc 43 }}-shutdown
   labels:
     {{- include "generic-service.labels" . | nindent 4 }}
+  annotations:
+    {{- include "generic-service.gitAnnotations" . | nindent 4 }}
 spec:
   schedule: {{ .Values.scheduledDowntime.shutdown }}
   timeZone: {{ .Values.scheduledDowntime.timeZone }}
@@ -46,6 +48,8 @@ metadata:
   name: {{ include "generic-service.cronPrefixName" . | trunc 43 }}-startup
   labels:
     {{- include "generic-service.labels" . | nindent 4 }}
+  annotations:
+    {{- include "generic-service.gitAnnotations" . | nindent 4 }}
 spec:
   schedule:  {{- if .Values.scheduledDowntime.startupOverride }} {{ .Values.scheduledDowntime.startupOverride }} {{- else }} {{ print $randomMinute " 6 * * 1-5" }} {{- end }}
   timeZone: {{ .Values.scheduledDowntime.timeZone }}

--- a/charts/generic-service/templates/service.yaml
+++ b/charts/generic-service/templates/service.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "generic-service.fullname" . }}
   labels:
     {{- include "generic-service.labels" . | nindent 4 }}
+  annotations:
+    {{- include "generic-service.gitAnnotations" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/generic-service/templates/servicemonitor.yaml
+++ b/charts/generic-service/templates/servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "generic-service.fullname" . }}
   labels:
     {{- include "generic-service.labels" . | nindent 4 }}
+  annotations:
+    {{- include "generic-service.gitAnnotations" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -21,6 +21,12 @@ fullnameOverride: ""
 # Product ID as specified in the service catalogue
 # productId: "ID"
 
+# Git metadata, normally supplied by CI/CD, used to annotate all resources so the source
+# of a deployment can be identified. Each defaults to "unknown" if not set.
+gitRepoUrl: ""
+gitCommitSha: ""
+gitRefName: ""
+
 # override docker image CMD
 containerArgs: []
 


### PR DESCRIPTION
This pull request adds Git metadata annotations to all Kubernetes resources managed by the `generic-service` Helm chart. These annotations make it easier to trace which repository, commit, and branch/tag deployed a given release, improving traceability and auditability of deployments. The changes introduce a new template for the Git metadata and update all relevant resource templates to include these annotations.

The most important changes are:

**Introduction of Git metadata annotations:**
* Added a new Helm template partial, `generic-service.gitAnnotations`, which defines annotations for `repo-url`, `commit-sha`, and `ref-name` using values from the chart or CI/CD pipeline. (`charts/generic-service/templates/_helpers.tpl`)
* Added new values (`gitRepoUrl`, `gitCommitSha`, `gitRefName`) to `values.yaml` for configuring these annotations. (`charts/generic-service/values.yaml`)

**Application of Git metadata to Kubernetes resources:**
* Updated all major resource templates (Deployment, Service, Ingress, HPA, PDB, ServiceMonitor, NetworkPolicy, CronJobs, and custom database backup/restore jobs) to include the new Git metadata annotations in their `metadata.annotations` sections. [[1]](diffhunk://#diff-3dcc66caa04462aaeef6a7613458fbc404ae71d15f6c877038138767009135b1R7-R8) [[2]](diffhunk://#diff-3dcc66caa04462aaeef6a7613458fbc404ae71d15f6c877038138767009135b1L22-R26) [[3]](diffhunk://#diff-538ce1591f1f54138c05479ef419ec01d3a6c2fcd0d4d7d7a91677e6b281d914R8-R9) [[4]](diffhunk://#diff-abe24911a3cee0037a7e9fccdf8b687493b27b1bcaec75727ff9014d3abf6198R15) [[5]](diffhunk://#diff-bfbd7bee6f47cf0f7bba7f4683d5572d0df67a26cad86509d6b182ce192bbdd4R8-R9) [[6]](diffhunk://#diff-2d24861fb1fc25b5f2ba46902632befc21d4042b67052c8ed4b523bc756ba0daR8-R9) [[7]](diffhunk://#diff-7793966d0872e553835d2a75bcb22aa4e124c531db56969e63d88e83beb745d4R8-R9) [[8]](diffhunk://#diff-0f096dc20ad0cc83004187edd9e0216dfe1269458cc9369dd7dedfcf8b0a6b9cR8-R9) [[9]](diffhunk://#diff-a59588e78e0b21185600893e00a756580d2823ca33c7461eb285bf9d1cfb81b0R10-R11) [[10]](diffhunk://#diff-127ffa10a5af25c86466f857c5c12cde1b3713bc9e599aa002a50f730891cca8R8-R9) [[11]](diffhunk://#diff-cbc777a979f9f5e48d3bb7ca60725644e397bfb3d42f3d06210ea5e4332e479aR12-R13) [[12]](diffhunk://#diff-cbc777a979f9f5e48d3bb7ca60725644e397bfb3d42f3d06210ea5e4332e479aR51-R52) [[13]](diffhunk://#diff-05c284f46ac6e737373b6ab847920a817a7fa36503f79b96ba2f19331c3e6601R22-R23) [[14]](diffhunk://#diff-05c284f46ac6e737373b6ab847920a817a7fa36503f79b96ba2f19331c3e6601R39-R40) [[15]](diffhunk://#diff-8fb33924797edb1e0650c16421e55b031b4397cab4511bf644c8caa99060b380R20-R21) [[16]](diffhunk://#diff-8fb33924797edb1e0650c16421e55b031b4397cab4511bf644c8caa99060b380R37-R38)

These changes ensure every deployment is annotated with its source, making debugging and auditing much easier.